### PR TITLE
fix: update dependencies to fix npm security vulnerabilities

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,6 @@
     "tsx": "^4.19.2",
     "typescript": "^5.5.2",
     "vitest": "^3.2.0",
-    "wrangler": "^4.58.0"
+    "wrangler": "^4.59.2"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,14 +11,14 @@
   },
   "dependencies": {
     "@gh-trend-tracker/shared-types": "*",
-    "astro": "^4.16.0",
-    "@astrojs/react": "^3.6.2",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "astro": "^5.16.11",
+    "@astrojs/react": "^4.4.2",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1",
+    "@types/react": "^19.1.6",
+    "@types/react-dom": "^19.1.6",
     "typescript": "^5.6.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,99 +32,139 @@
         "tsx": "^4.19.2",
         "typescript": "^5.5.2",
         "vitest": "^3.2.0",
-        "wrangler": "^4.58.0"
+        "wrangler": "^4.59.2"
       }
     },
     "apps/web": {
       "name": "@gh-trend-tracker/web",
       "version": "0.1.0",
       "dependencies": {
-        "@astrojs/react": "^3.6.2",
+        "@astrojs/react": "^4.4.2",
         "@gh-trend-tracker/shared-types": "*",
-        "astro": "^4.16.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "astro": "^5.16.11",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0"
       },
       "devDependencies": {
-        "@types/react": "^18.3.12",
-        "@types/react-dom": "^18.3.1",
+        "@types/react": "^19.1.6",
+        "@types/react-dom": "^19.1.6",
         "typescript": "^5.6.3"
       }
+    },
+    "apps/web/node_modules/@types/react": {
+      "version": "19.2.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "apps/web/node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "apps/web/node_modules/react": {
+      "version": "19.2.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "apps/web/node_modules/react-dom": {
+      "version": "19.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.3"
+      }
+    },
+    "apps/web/node_modules/scheduler": {
+      "version": "0.27.0",
+      "license": "MIT"
     },
     "node_modules/@astrojs/compiler": {
       "version": "2.13.0",
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.4.1",
+      "version": "0.7.5",
       "license": "MIT"
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "5.3.0",
+      "version": "6.3.10",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/prism": "3.1.0",
+        "@astrojs/internal-helpers": "0.7.5",
+        "@astrojs/prism": "3.3.0",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-text": "^4.0.2",
-        "import-meta-resolve": "^4.1.0",
+        "import-meta-resolve": "^4.2.0",
+        "js-yaml": "^4.1.1",
         "mdast-util-definitions": "^6.0.0",
         "rehype-raw": "^7.0.0",
         "rehype-stringify": "^10.0.1",
-        "remark-gfm": "^4.0.0",
+        "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.1.1",
+        "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
-        "shiki": "^1.22.0",
+        "shiki": "^3.19.0",
+        "smol-toml": "^1.5.2",
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
         "unist-util-visit": "^5.0.0",
-        "unist-util-visit-parents": "^6.0.1",
+        "unist-util-visit-parents": "^6.0.2",
         "vfile": "^6.0.3"
       }
     },
     "node_modules/@astrojs/prism": {
-      "version": "3.1.0",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
-        "prismjs": "^1.29.0"
+        "prismjs": "^1.30.0"
       },
       "engines": {
-        "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
       }
     },
     "node_modules/@astrojs/react": {
-      "version": "3.6.3",
+      "version": "4.4.2",
       "license": "MIT",
       "dependencies": {
-        "@vitejs/plugin-react": "^4.3.3",
-        "ultrahtml": "^1.5.3",
-        "vite": "^5.4.10"
+        "@vitejs/plugin-react": "^4.7.0",
+        "ultrahtml": "^1.6.0",
+        "vite": "^6.4.1"
       },
       "engines": {
-        "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
       },
       "peerDependencies": {
-        "@types/react": "^17.0.50 || ^18.0.21",
-        "@types/react-dom": "^17.0.17 || ^18.0.6",
-        "react": "^17.0.2 || ^18.0.0 || ^19.0.0-beta",
-        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0-beta"
+        "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0",
+        "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
+        "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@astrojs/telemetry": {
-      "version": "3.1.0",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
-        "ci-info": "^4.0.0",
-        "debug": "^4.3.4",
+        "ci-info": "^4.2.0",
+        "debug": "^4.4.0",
         "dlv": "^1.1.3",
-        "dset": "^3.1.3",
+        "dset": "^3.1.4",
         "is-docker": "^3.0.0",
-        "is-wsl": "^3.0.0",
+        "is-wsl": "^3.1.0",
         "which-pm-runs": "^1.1.0"
       },
       "engines": {
-        "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -190,16 +230,6 @@
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.27.3",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.27.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -311,36 +341,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.28.6",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.3",
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/plugin-syntax-jsx": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-transform-react-jsx-self": {
       "version": "7.27.1",
       "license": "MIT",
@@ -406,6 +406,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@capsizecss/unpack": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "fontkitten": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.4.2",
       "dev": true,
@@ -458,70 +468,6 @@
         }
       }
     },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/aix-ppc64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/android-x64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/darwin-x64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/freebsd-x64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ia32": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-loong64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-mips64el": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-ppc64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-riscv64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-s390x": {
-      "dev": true,
-      "optional": true
-    },
     "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/linux-x64": {
       "version": "0.25.4",
       "cpu": [
@@ -537,27 +483,11 @@
         "node": ">=18"
       }
     },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-x64": {
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/netbsd-arm64": {
       "dev": true,
       "optional": true
     },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-x64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/sunos-x64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-ia32": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/win32-x64": {
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/@esbuild/openbsd-arm64": {
       "dev": true,
       "optional": true
     },
@@ -599,6 +529,94 @@
         "@esbuild/win32-ia32": "0.25.4",
         "@esbuild/win32-x64": "0.25.4"
       }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/android-arm": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/android-x64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/esbuild/node_modules/@esbuild/win32-x64": {
+      "dev": true,
+      "optional": true
     },
     "node_modules/@cloudflare/vitest-pool-workers/node_modules/unenv": {
       "version": "2.0.0-rc.21",
@@ -908,7 +926,7 @@
       "optional": true
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
+      "version": "0.25.12",
       "cpu": [
         "x64"
       ],
@@ -918,25 +936,22 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "dev": true,
       "optional": true
     },
     "node_modules/@esbuild/netbsd-x64": {
       "optional": true
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "dev": true,
       "optional": true
     },
     "node_modules/@esbuild/openbsd-x64": {
       "optional": true
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "dev": true,
       "optional": true
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -965,28 +980,34 @@
     },
     "node_modules/@img/colour": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
+      "dev": true,
       "optional": true
     },
     "node_modules/@img/sharp-darwin-x64": {
+      "dev": true,
       "optional": true
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "dev": true,
       "optional": true
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
+      "dev": true,
       "optional": true
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
+      "dev": true,
       "optional": true
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
+      "dev": true,
       "optional": true
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
@@ -998,6 +1019,7 @@
       "optional": true
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
+      "dev": true,
       "optional": true
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
@@ -1005,6 +1027,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1015,15 +1038,19 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "dev": true,
       "optional": true
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "dev": true,
       "optional": true
     },
     "node_modules/@img/sharp-linux-arm": {
+      "dev": true,
       "optional": true
     },
     "node_modules/@img/sharp-linux-arm64": {
+      "dev": true,
       "optional": true
     },
     "node_modules/@img/sharp-linux-ppc64": {
@@ -1035,6 +1062,7 @@
       "optional": true
     },
     "node_modules/@img/sharp-linux-s390x": {
+      "dev": true,
       "optional": true
     },
     "node_modules/@img/sharp-linux-x64": {
@@ -1042,6 +1070,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1058,12 +1087,15 @@
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
+      "dev": true,
       "optional": true
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
+      "dev": true,
       "optional": true
     },
     "node_modules/@img/sharp-wasm32": {
+      "dev": true,
       "optional": true
     },
     "node_modules/@img/sharp-win32-arm64": {
@@ -1071,9 +1103,11 @@
       "optional": true
     },
     "node_modules/@img/sharp-win32-ia32": {
+      "dev": true,
       "optional": true
     },
     "node_modules/@img/sharp-win32-x64": {
+      "dev": true,
       "optional": true
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1109,35 +1143,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/@oslojs/encoding": {
@@ -1279,53 +1284,51 @@
       "optional": true
     },
     "node_modules/@shikijs/core": {
-      "version": "1.29.2",
+      "version": "3.21.0",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/engine-javascript": "1.29.2",
-        "@shikijs/engine-oniguruma": "1.29.2",
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1",
+        "@shikijs/types": "3.21.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
-        "hast-util-to-html": "^9.0.4"
+        "hast-util-to-html": "^9.0.5"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "1.29.2",
+      "version": "3.21.0",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1",
-        "oniguruma-to-es": "^2.2.0"
+        "@shikijs/types": "3.21.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "1.29.2",
+      "version": "3.21.0",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1"
+        "@shikijs/types": "3.21.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "1.29.2",
+      "version": "3.21.0",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "1.29.2"
+        "@shikijs/types": "3.21.0"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "1.29.2",
+      "version": "3.21.0",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "1.29.2"
+        "@shikijs/types": "3.21.0"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "1.29.2",
+      "version": "3.21.0",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }
     },
@@ -1391,10 +1394,6 @@
         "assertion-error": "^2.0.1"
       }
     },
-    "node_modules/@types/cookie": {
-      "version": "0.6.0",
-      "license": "MIT"
-    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "license": "MIT",
@@ -1446,11 +1445,13 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/react": {
       "version": "18.3.27",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1459,6 +1460,7 @@
     "node_modules/@types/react-dom": {
       "version": "18.3.7",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1668,6 +1670,27 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "license": "Python-2.0"
@@ -1696,82 +1719,237 @@
       }
     },
     "node_modules/astro": {
-      "version": "4.16.19",
+      "version": "5.16.11",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler": "^2.10.3",
-        "@astrojs/internal-helpers": "0.4.1",
-        "@astrojs/markdown-remark": "5.3.0",
-        "@astrojs/telemetry": "3.1.0",
-        "@babel/core": "^7.26.0",
-        "@babel/plugin-transform-react-jsx": "^7.25.9",
-        "@babel/types": "^7.26.0",
+        "@astrojs/compiler": "^2.13.0",
+        "@astrojs/internal-helpers": "0.7.5",
+        "@astrojs/markdown-remark": "6.3.10",
+        "@astrojs/telemetry": "3.3.0",
+        "@capsizecss/unpack": "^4.0.0",
         "@oslojs/encoding": "^1.1.0",
-        "@rollup/pluginutils": "^5.1.3",
-        "@types/babel__core": "^7.20.5",
-        "@types/cookie": "^0.6.0",
-        "acorn": "^8.14.0",
+        "@rollup/pluginutils": "^5.3.0",
+        "acorn": "^8.15.0",
         "aria-query": "^5.3.2",
         "axobject-query": "^4.1.0",
         "boxen": "8.0.1",
-        "ci-info": "^4.1.0",
+        "ci-info": "^4.3.1",
         "clsx": "^2.1.1",
         "common-ancestor-path": "^1.0.1",
-        "cookie": "^0.7.2",
+        "cookie": "^1.1.1",
         "cssesc": "^3.0.0",
-        "debug": "^4.3.7",
+        "debug": "^4.4.3",
         "deterministic-object-hash": "^2.0.2",
-        "devalue": "^5.1.1",
-        "diff": "^5.2.0",
+        "devalue": "^5.6.2",
+        "diff": "^8.0.3",
         "dlv": "^1.1.3",
         "dset": "^3.1.4",
-        "es-module-lexer": "^1.5.4",
-        "esbuild": "^0.21.5",
+        "es-module-lexer": "^1.7.0",
+        "esbuild": "^0.25.0",
         "estree-walker": "^3.0.3",
-        "fast-glob": "^3.3.2",
         "flattie": "^1.1.1",
+        "fontace": "~0.4.0",
         "github-slugger": "^2.0.0",
-        "gray-matter": "^4.0.3",
-        "html-escaper": "^3.0.3",
-        "http-cache-semantics": "^4.1.1",
-        "js-yaml": "^4.1.0",
-        "kleur": "^4.1.5",
-        "magic-string": "^0.30.14",
-        "magicast": "^0.3.5",
-        "micromatch": "^4.0.8",
-        "mrmime": "^2.0.0",
+        "html-escaper": "3.0.3",
+        "http-cache-semantics": "^4.2.0",
+        "import-meta-resolve": "^4.2.0",
+        "js-yaml": "^4.1.1",
+        "magic-string": "^0.30.21",
+        "magicast": "^0.5.1",
+        "mrmime": "^2.0.1",
         "neotraverse": "^0.6.18",
-        "ora": "^8.1.1",
-        "p-limit": "^6.1.0",
-        "p-queue": "^8.0.1",
-        "preferred-pm": "^4.0.0",
+        "p-limit": "^6.2.0",
+        "p-queue": "^8.1.1",
+        "package-manager-detector": "^1.6.0",
+        "piccolore": "^0.1.3",
+        "picomatch": "^4.0.3",
         "prompts": "^2.4.2",
         "rehype": "^13.0.2",
-        "semver": "^7.6.3",
-        "shiki": "^1.23.1",
-        "tinyexec": "^0.3.1",
-        "tsconfck": "^3.1.4",
+        "semver": "^7.7.3",
+        "shiki": "^3.20.0",
+        "smol-toml": "^1.6.0",
+        "svgo": "^4.0.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tsconfck": "^3.1.6",
+        "ultrahtml": "^1.6.0",
+        "unifont": "~0.7.1",
         "unist-util-visit": "^5.0.0",
+        "unstorage": "^1.17.3",
         "vfile": "^6.0.3",
-        "vite": "^5.4.11",
-        "vitefu": "^1.0.4",
-        "which-pm": "^3.0.0",
+        "vite": "^6.4.1",
+        "vitefu": "^1.1.1",
         "xxhash-wasm": "^1.1.0",
         "yargs-parser": "^21.1.1",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.23.5",
+        "yocto-spinner": "^0.2.3",
+        "zod": "^3.25.76",
+        "zod-to-json-schema": "^3.25.1",
         "zod-to-ts": "^1.2.0"
       },
       "bin": {
         "astro": "astro.js"
       },
       "engines": {
-        "node": "^18.17.1 || ^20.3.0 || >=21.0.0",
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0",
         "npm": ">=9.6.5",
         "pnpm": ">=7.1.0"
       },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/astrodotbuild"
+      },
       "optionalDependencies": {
-        "sharp": "^0.33.3"
+        "sharp": "^0.34.0"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-darwin-arm64": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-darwin-x64": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-libvips-darwin-x64": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-libvips-linux-arm": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-libvips-linux-arm64": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-libvips-linux-ppc64": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-libvips-linux-riscv64": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-libvips-linux-s390x": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-linux-arm": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-linux-arm64": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-linux-ppc64": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-linux-riscv64": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-linux-s390x": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/astro/node_modules/@img/sharp-linuxmusl-arm64": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-linuxmusl-x64": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-wasm32": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-win32-arm64": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-win32-ia32": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/@img/sharp-win32-x64": {
+      "optional": true
+    },
+    "node_modules/astro/node_modules/sharp": {
+      "version": "0.34.5",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/astro/node_modules/tinyexec": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/axobject-query": {
@@ -1813,6 +1991,10 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "license": "ISC"
+    },
     "node_modules/boxen": {
       "version": "8.0.1",
       "license": "MIT",
@@ -1831,16 +2013,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/browserslist": {
@@ -1980,6 +2152,19 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/ci-info": {
       "version": "4.3.1",
       "funding": [
@@ -2008,29 +2193,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cli-cursor": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "license": "MIT",
@@ -2040,7 +2202,7 @@
     },
     "node_modules/color": {
       "version": "4.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1",
@@ -2052,7 +2214,7 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2063,12 +2225,12 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
       "version": "1.9.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "^1.0.0",
@@ -2083,6 +2245,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/common-ancestor-path": {
       "version": "1.0.1",
       "license": "ISC"
@@ -2092,10 +2261,60 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.7.2",
+      "version": "1.1.1",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cookie-es": {
+      "version": "1.2.2",
+      "license": "MIT"
+    },
+    "node_modules/crossws": {
+      "version": "0.3.5",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssesc": {
@@ -2107,6 +2326,33 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "license": "CC0-1.0"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -2148,7 +2394,6 @@
     },
     "node_modules/defu": {
       "version": "6.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dequal": {
@@ -2157,6 +2402,10 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -2192,7 +2441,7 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.0",
+      "version": "8.0.3",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -2201,6 +2450,63 @@
     "node_modules/dlv": {
       "version": "1.1.3",
       "license": "MIT"
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
     },
     "node_modules/drizzle-kit": {
       "version": "0.31.8",
@@ -2214,157 +2520,6 @@
       },
       "bin": {
         "drizzle-kit": "bin.cjs"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/aix-ppc64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/android-arm": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/android-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/android-x64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/darwin-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/darwin-x64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/freebsd-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/freebsd-x64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/linux-arm": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/linux-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/linux-ia32": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/linux-loong64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/linux-mips64el": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/linux-ppc64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/linux-riscv64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/linux-s390x": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/netbsd-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/netbsd-x64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/openbsd-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/openbsd-x64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/sunos-x64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/win32-arm64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/win32-ia32": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/@esbuild/win32-x64": {
-      "dev": true,
-      "optional": true
-    },
-    "node_modules/drizzle-kit/node_modules/esbuild": {
-      "version": "0.25.12",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/drizzle-orm": {
@@ -2505,10 +2660,6 @@
       "version": "10.6.0",
       "license": "MIT"
     },
-    "node_modules/emoji-regex-xs": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/entities": {
       "version": "6.0.1",
       "license": "BSD-2-Clause",
@@ -2532,39 +2683,42 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.21.5",
+      "version": "0.25.12",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/esbuild-register": {
@@ -2593,17 +2747,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/estree-walker": {
@@ -2645,40 +2788,8 @@
       "version": "3.0.2",
       "license": "MIT"
     },
-    "node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -2692,50 +2803,28 @@
         }
       }
     },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/find-up": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/find-up-simple": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/find-yarn-workspace-root2": {
-      "version": "1.2.16",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "micromatch": "^4.0.2",
-        "pkg-dir": "^4.2.0"
-      }
-    },
     "node_modules/flattie": {
       "version": "1.1.1",
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/fontace": {
+      "version": "0.4.0",
+      "license": "MIT",
+      "dependencies": {
+        "fontkitten": "^1.0.0"
+      }
+    },
+    "node_modules/fontkitten": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-inflate": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/fsevents": {
@@ -2760,7 +2849,7 @@
     },
     "node_modules/get-tsconfig": {
       "version": "4.13.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -2773,54 +2862,24 @@
       "version": "2.0.0",
       "license": "ISC"
     },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "dev": true,
       "license": "BSD-2-Clause"
     },
-    "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "license": "ISC"
-    },
-    "node_modules/gray-matter": {
-      "version": "4.0.3",
+    "node_modules/h3": {
+      "version": "1.15.5",
       "license": "MIT",
       "dependencies": {
-        "js-yaml": "^3.13.1",
-        "kind-of": "^6.0.2",
-        "section-matter": "^1.0.0",
-        "strip-bom-string": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/gray-matter/node_modules/argparse": {
-      "version": "1.0.10",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "cookie-es": "^1.2.2",
+        "crossws": "^0.3.5",
+        "defu": "^6.1.4",
+        "destr": "^2.0.5",
+        "iron-webcrypto": "^1.2.1",
+        "node-mock-http": "^1.0.4",
+        "radix3": "^1.1.2",
+        "ufo": "^1.6.3",
+        "uncrypto": "^0.1.3"
       }
     },
     "node_modules/hast-util-from-html": {
@@ -3011,9 +3070,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/iron-webcrypto": {
+      "version": "1.2.1",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-docker": {
@@ -3029,35 +3095,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-inside-container": {
@@ -3076,38 +3118,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-interactive": {
-      "version": "2.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3160,83 +3175,12 @@
         "node": ">=6"
       }
     },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/kleur": {
       "version": "4.1.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/load-yaml-file": {
-      "version": "0.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.5",
-        "js-yaml": "^3.13.0",
-        "pify": "^4.0.1",
-        "strip-bom": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/load-yaml-file/node_modules/argparse": {
-      "version": "1.0.10",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/load-yaml-file/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/locate-path": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/log-symbols": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.3.0",
-        "is-unicode-supported": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-symbols/node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/longest-streak": {
@@ -3250,6 +3194,7 @@
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -3277,12 +3222,12 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.3.5",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.25.4",
-        "@babel/types": "^7.25.4",
-        "source-map-js": "^1.2.0"
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/markdown-table": {
@@ -3492,12 +3437,9 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "license": "CC0-1.0"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -4006,27 +3948,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mime": {
       "version": "3.0.0",
       "dev": true,
@@ -4036,16 +3957,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/mimic-function": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/miniflare": {
@@ -4137,56 +4048,59 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "license": "MIT"
+    },
+    "node_modules/node-mock-http": {
+      "version": "1.0.4",
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "license": "MIT"
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/ofetch": {
+      "version": "1.5.1",
+      "license": "MIT",
+      "dependencies": {
+        "destr": "^2.0.5",
+        "node-fetch-native": "^1.6.7",
+        "ufo": "^1.6.1"
+      }
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
-      "dev": true,
       "license": "MIT"
     },
-    "node_modules/onetime": {
-      "version": "7.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-function": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.1",
+      "license": "MIT"
     },
     "node_modules/oniguruma-to-es": {
-      "version": "2.3.0",
+      "version": "4.3.4",
       "license": "MIT",
       "dependencies": {
-        "emoji-regex-xs": "^1.0.0",
-        "regex": "^5.1.1",
-        "regex-recursion": "^5.1.1"
-      }
-    },
-    "node_modules/ora": {
-      "version": "8.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.3.0",
-        "cli-cursor": "^5.0.0",
-        "cli-spinners": "^2.9.2",
-        "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^2.0.0",
-        "log-symbols": "^6.0.0",
-        "stdin-discarder": "^0.2.2",
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "oniguruma-parser": "^0.12.1",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
       }
     },
     "node_modules/p-limit": {
@@ -4197,29 +4111,6 @@
       },
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-locate": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-locate/node_modules/p-limit": {
-      "version": "2.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4249,12 +4140,9 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "license": "MIT"
     },
     "node_modules/parse-latin": {
       "version": "7.0.0",
@@ -4282,13 +4170,6 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/path-exists": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
       "dev": true,
@@ -4307,6 +4188,10 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/piccolore": {
+      "version": "0.1.3",
+      "license": "ISC"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "license": "ISC"
@@ -4319,23 +4204,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pify": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-dir": {
-      "version": "4.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/postcss": {
@@ -4362,18 +4230,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/preferred-pm": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "find-up-simple": "^1.0.0",
-        "find-yarn-workspace-root2": "1.2.16",
-        "which-pm": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18.12"
       }
     },
     "node_modules/prismjs": {
@@ -4409,27 +4265,14 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
+    "node_modules/radix3": {
+      "version": "1.1.2",
       "license": "MIT"
     },
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4440,6 +4283,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4455,18 +4299,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/regex": {
-      "version": "5.1.1",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
       }
     },
     "node_modules/regex-recursion": {
-      "version": "5.1.1",
+      "version": "6.0.2",
       "license": "MIT",
       "dependencies": {
-        "regex": "^5.1.1",
         "regex-utilities": "^2.3.0"
       }
     },
@@ -4600,24 +4454,10 @@
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
-    "node_modules/restore-cursor": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^7.0.0",
-        "signal-exit": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/retext": {
@@ -4673,14 +4513,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.55.1",
       "license": "MIT",
@@ -4723,43 +4555,19 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
+    "node_modules/sax": {
+      "version": "1.4.4",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
       }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/section-matter": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "kind-of": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/semver": {
@@ -4774,7 +4582,7 @@
     },
     "node_modules/sharp": {
       "version": "0.33.5",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4811,16 +4619,16 @@
       }
     },
     "node_modules/shiki": {
-      "version": "1.29.2",
+      "version": "3.21.0",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "1.29.2",
-        "@shikijs/engine-javascript": "1.29.2",
-        "@shikijs/engine-oniguruma": "1.29.2",
-        "@shikijs/langs": "1.29.2",
-        "@shikijs/themes": "1.29.2",
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1",
+        "@shikijs/core": "3.21.0",
+        "@shikijs/engine-javascript": "3.21.0",
+        "@shikijs/engine-oniguruma": "3.21.0",
+        "@shikijs/langs": "3.21.0",
+        "@shikijs/themes": "3.21.0",
+        "@shikijs/types": "3.21.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }
     },
@@ -4829,19 +4637,9 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/simple-swizzle": {
       "version": "0.2.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.3.1"
@@ -4850,6 +4648,16 @@
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "license": "MIT"
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.0",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -4883,10 +4691,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "dev": true,
@@ -4896,16 +4700,6 @@
       "version": "3.10.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/stdin-discarder": {
-      "version": "0.2.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/stoppable": {
       "version": "1.1.0",
@@ -4956,20 +4750,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/strip-bom": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/strip-bom-string": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/strip-literal": {
       "version": "3.1.0",
       "dev": true,
@@ -4997,6 +4777,33 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/svgo": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^11.1.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^3.0.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.1.1",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "svgo": "bin/svgo.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "dev": true,
@@ -5004,11 +4811,11 @@
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -5043,16 +4850,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/trim-lines": {
@@ -5091,7 +4888,7 @@
     },
     "node_modules/tsx": {
       "version": "4.21.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -5108,123 +4905,123 @@
       }
     },
     "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/android-arm": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/android-arm64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/android-x64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/linux-arm": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/linux-x64": {
       "version": "0.27.2",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/@esbuild/win32-x64": {
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx/node_modules/esbuild": {
       "version": "0.27.2",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5285,11 +5082,14 @@
     },
     "node_modules/ufo": {
       "version": "1.6.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ultrahtml": {
       "version": "1.6.0",
+      "license": "MIT"
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
       "license": "MIT"
     },
     "node_modules/undici": {
@@ -5328,6 +5128,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unifont": {
+      "version": "0.7.3",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.1.0",
+        "ofetch": "^1.5.1",
+        "ohash": "^2.0.11"
       }
     },
     "node_modules/unist-util-find-after": {
@@ -5435,6 +5244,107 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unstorage": {
+      "version": "1.17.4",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^3.1.3",
+        "chokidar": "^5.0.0",
+        "destr": "^2.0.5",
+        "h3": "^1.15.5",
+        "lru-cache": "^11.2.0",
+        "node-fetch-native": "^1.6.7",
+        "ofetch": "^1.5.1",
+        "ufo": "^1.6.3"
+      },
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.8.0",
+        "@azure/cosmos": "^4.2.0",
+        "@azure/data-tables": "^13.3.0",
+        "@azure/identity": "^4.6.0",
+        "@azure/keyvault-secrets": "^4.9.0",
+        "@azure/storage-blob": "^12.26.0",
+        "@capacitor/preferences": "^6 || ^7 || ^8",
+        "@deno/kv": ">=0.9.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.34.3",
+        "@vercel/blob": ">=0.27.1",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
+        "@vercel/kv": "^1 || ^2 || ^3",
+        "aws4fetch": "^1.0.20",
+        "db0": ">=0.2.1",
+        "idb-keyval": "^6.2.1",
+        "ioredis": "^5.4.2",
+        "uploadthing": "^7.4.4"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@deno/kv": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "db0": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "uploadthing": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/unstorage/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "funding": [
@@ -5500,18 +5410,21 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.21",
+      "version": "6.4.1",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -5520,17 +5433,23 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
         "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
-        "terser": "^5.4.0"
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "@types/node": {
+          "optional": true
+        },
+        "jiti": {
           "optional": true
         },
         "less": {
@@ -5552,6 +5471,12 @@
           "optional": true
         },
         "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
           "optional": true
         }
       }
@@ -5576,6 +5501,9 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "optional": true
     },
     "node_modules/vitefu": {
       "version": "1.1.1",
@@ -5671,16 +5599,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/which-pm": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "load-yaml-file": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=18.12"
       }
     },
     "node_modules/which-pm-runs": {
@@ -6074,6 +5992,10 @@
         "@esbuild/win32-x64": "0.27.0"
       }
     },
+    "node_modules/wrangler/node_modules/fsevents": {
+      "dev": true,
+      "optional": true
+    },
     "node_modules/wrangler/node_modules/miniflare": {
       "version": "4.20260114.0",
       "dev": true,
@@ -6224,6 +6146,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/yocto-spinner": {
+      "version": "0.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.19"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/youch": {
       "version": "4.1.0-beta.10",
       "dev": true,
@@ -6243,18 +6188,6 @@
       "dependencies": {
         "@poppinss/exception": "^1.2.2",
         "error-stack-parser-es": "^1.0.5"
-      }
-    },
-    "node_modules/youch/node_modules/cookie": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/zod": {


### PR DESCRIPTION
## Summary
- Update astro from 4.16.0 to 5.16.11 (major version upgrade)
- Update @astrojs/react from 3.6.2 to 4.4.2
- Update React/React-DOM from 18.3.1 to 19.1.0
- Update wrangler from 4.58.0 to 4.59.2

## Resolved Vulnerabilities
The following high/critical vulnerabilities are now fixed:
- **Astro XSS**: X-Forwarded-Host reflection (GHSA-5ff5-9fcw-vg88)
- **Astro XSS**: Server islands reflected XSS (GHSA-wrwg-2hg8-v723)
- **Astro Auth Bypass**: Middleware bypass via URL encoding (GHSA-ggxq-hp9w-j794)
- **Astro Auth Bypass**: Double URL encoding bypass (GHSA-whqg-ppgf-wp8c)
- **Astro XSS**: Cloudflare adapter /_image endpoint (GHSA-fvmw-cj7j-j39q)
- **jsdiff DoS**: parsePatch/applyPatch vulnerability (GHSA-73rr-hh4g-fpgx)

## Remaining Vulnerabilities (7 low/moderate)
These are in transitive dependencies and require upstream fixes:
- **esbuild** (via drizzle-kit → @esbuild-kit/esm-loader): Dev server request reading
- **undici** (via wrangler → miniflare): Decompression chain DoS

These affect development tooling only and do not impact production.

## Test Plan
- [x] `npm install` succeeds
- [x] `npm run build:web` builds successfully
- [x] `npm run test:api` passes (1 test)
- [x] `npm audit` shows reduced vulnerabilities (11 → 7)

## Breaking Changes
- **Astro 5**: No code changes required for this project
- **React 19**: No code changes required for this project

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)