### PR TITLE
feat: ヘルスチェックにデータベース接続確認を追加

### DIFF
--- a/apps/backend/openapi/openapi.yaml
+++ b/apps/backend/openapi/openapi.yaml
@@ -65,10 +65,16 @@ paths:
       tags:
         - Health
       summary: ヘルスチェック
-      description: APIサーバーの稼働状態を確認します
+      description: |
+        APIサーバーの稼働状態とデータベース接続状態を確認します。
+
+        - status: ok - サービスが正常に稼働中
+        - status: unhealthy - サービスに問題がある（DB接続エラーなど）
+        - database: connected - データベース接続が正常
+        - database: disconnected - データベース接続に問題あり
       responses:
         200:
-          description: サービスが正常に稼働中
+          description: サービスが正常に稼働中（データベース接続OK）
           content:
             application/json:
               schema:
@@ -76,15 +82,55 @@ paths:
                 properties:
                   status:
                     type: string
+                    enum:
+                      - ok
+                      - unhealthy
                     description: サービスの状態
                     example: ok
                   timestamp:
                     type: string
                     description: 現在のタイムスタンプ（ISO 8601形式）
                     example: "2026-01-17T12:00:00.000Z"
+                  database:
+                    type: string
+                    enum:
+                      - connected
+                      - disconnected
+                    description: データベース接続状態
+                    example: connected
                 required:
                   - status
                   - timestamp
+                  - database
+        503:
+          description: サービスが異常状態（データベース接続エラー）
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - ok
+                      - unhealthy
+                    description: サービスの状態
+                    example: unhealthy
+                  timestamp:
+                    type: string
+                    description: 現在のタイムスタンプ（ISO 8601形式）
+                    example: "2026-01-17T12:00:00.000Z"
+                  database:
+                    type: string
+                    enum:
+                      - connected
+                      - disconnected
+                    description: データベース接続状態
+                    example: disconnected
+                required:
+                  - status
+                  - timestamp
+                  - database
   /api/trends:
     get:
       tags:

--- a/apps/backend/src/routes/health.ts
+++ b/apps/backend/src/routes/health.ts
@@ -1,15 +1,34 @@
 import { Hono } from 'hono';
+import { drizzle } from 'drizzle-orm/d1';
+import { sql } from 'drizzle-orm';
 import type { HealthResponse } from '@gh-trend-tracker/shared';
 import type { Bindings } from '../types/bindings';
 
 const health = new Hono<{ Bindings: Bindings }>();
 
-health.get('/', (c) => {
-  const response: HealthResponse = {
-    status: 'ok',
-    timestamp: new Date().toISOString(),
-  };
-  return c.json(response);
+health.get('/', async (c) => {
+  const timestamp = new Date().toISOString();
+
+  try {
+    const db = drizzle(c.env.DB);
+    // 軽量なクエリでDB接続確認
+    await db.run(sql`SELECT 1`);
+
+    const response: HealthResponse = {
+      status: 'ok',
+      timestamp,
+      database: 'connected',
+    };
+    return c.json(response);
+  } catch (error) {
+    console.error('Health check failed - database connection error:', error);
+    const response: HealthResponse = {
+      status: 'unhealthy',
+      timestamp,
+      database: 'disconnected',
+    };
+    return c.json(response, 503);
+  }
 });
 
 export default health;

--- a/apps/backend/test/health.spec.ts
+++ b/apps/backend/test/health.spec.ts
@@ -1,13 +1,14 @@
-import { env, SELF } from 'cloudflare:test';
+import { SELF } from 'cloudflare:test';
 import { describe, it, expect } from 'vitest';
 
 describe('Health endpoint', () => {
-  it('GET /health returns status ok', async () => {
+  it('GET /health returns status ok with database connected', async () => {
     const response = await SELF.fetch('http://example.com/health');
     expect(response.status).toBe(200);
 
     const data = await response.json();
     expect(data).toHaveProperty('status', 'ok');
     expect(data).toHaveProperty('timestamp');
+    expect(data).toHaveProperty('database', 'connected');
   });
 });

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -57,8 +57,9 @@ export interface LanguagesResponse {
 }
 
 export interface HealthResponse {
-  status: string;
+  status: 'ok' | 'unhealthy';
   timestamp: string;
+  database: 'connected' | 'disconnected';
 }
 
 export interface ErrorResponse {


### PR DESCRIPTION
## Summary
- `/health` エンドポイントにデータベース接続確認を追加
- DB接続成功時: `status: ok`, `database: connected`, HTTP 200
- DB接続失敗時: `status: unhealthy`, `database: disconnected`, HTTP 503

## Changes
- `apps/backend/src/routes/health.ts`: DB接続チェックロジックを追加
- `shared/src/index.ts`: `HealthResponse` 型に `database` フィールドを追加
- `apps/backend/test/health.spec.ts`: テストを更新
- `apps/backend/openapi/openapi.yaml`: OpenAPI仕様書を更新（503レスポンスを追加）

## Test plan
- [x] 既存のヘルスチェックテストが通ること
- [x] TypeScript型チェックが通ること

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)