### PR TITLE
perf: add database middleware to reuse Drizzle instance per request

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -4,12 +4,16 @@ import health from './routes/health';
 import trends from './routes/trends';
 import repositories from './routes/repositories';
 import languages from './routes/languages';
-import type { Bindings } from './types/bindings';
+import { dbMiddleware } from './middleware/database';
+import type { AppEnv } from './types/app';
 
-const app = new Hono<{ Bindings: Bindings }>();
+const app = new Hono<AppEnv>();
 
 // CORS設定（開発用、本番では制限すべき）
 app.use('/*', cors());
+
+// データベースミドルウェア
+app.use('/*', dbMiddleware);
 
 // ルート登録
 app.route('/health', health);

--- a/apps/backend/src/middleware/database.ts
+++ b/apps/backend/src/middleware/database.ts
@@ -1,0 +1,20 @@
+/**
+ * データベースミドルウェア
+ * リクエストごとにDrizzleインスタンスを一度だけ生成し、コンテキストに保存する
+ */
+import { createMiddleware } from 'hono/factory';
+import { drizzle } from 'drizzle-orm/d1';
+import type { DrizzleD1Database } from 'drizzle-orm/d1';
+import type { Bindings } from '../types/bindings';
+
+export type Variables = {
+  db: DrizzleD1Database;
+};
+
+export const dbMiddleware = createMiddleware<{
+  Bindings: Bindings;
+  Variables: Variables;
+}>(async (c, next) => {
+  c.set('db', drizzle(c.env.DB));
+  await next();
+});

--- a/apps/backend/src/routes/health.ts
+++ b/apps/backend/src/routes/health.ts
@@ -1,16 +1,15 @@
 import { Hono } from 'hono';
-import { drizzle } from 'drizzle-orm/d1';
 import { sql } from 'drizzle-orm';
 import type { HealthResponse } from '@gh-trend-tracker/shared';
-import type { Bindings } from '../types/bindings';
+import type { AppEnv } from '../types/app';
 
-const health = new Hono<{ Bindings: Bindings }>();
+const health = new Hono<AppEnv>();
 
 health.get('/', async (c) => {
   const timestamp = new Date().toISOString();
 
   try {
-    const db = drizzle(c.env.DB);
+    const db = c.get('db');
     // 軽量なクエリでDB接続確認
     await db.run(sql`SELECT 1`);
 

--- a/apps/backend/src/routes/languages.ts
+++ b/apps/backend/src/routes/languages.ts
@@ -1,14 +1,13 @@
 import { Hono } from 'hono';
-import { drizzle } from 'drizzle-orm/d1';
 import { getAllLanguages } from '../shared/queries';
 import type { LanguagesResponse, ErrorResponse } from '@gh-trend-tracker/shared';
-import type { Bindings } from '../types/bindings';
+import type { AppEnv } from '../types/app';
 
-const languages = new Hono<{ Bindings: Bindings }>();
+const languages = new Hono<AppEnv>();
 
 // 言語一覧
 languages.get('/', async (c) => {
-  const db = drizzle(c.env.DB);
+  const db = c.get('db');
 
   try {
     const languagesList = await getAllLanguages(db);

--- a/apps/backend/src/routes/repositories.ts
+++ b/apps/backend/src/routes/repositories.ts
@@ -1,12 +1,11 @@
 import { Hono } from 'hono';
-import { drizzle } from 'drizzle-orm/d1';
 import { getRepositoryHistory } from '../shared/queries';
 import { DEFAULT_HISTORY_DAYS } from '../shared/constants';
 import { parsePositiveInt } from '../shared/utils';
 import type { HistoryResponse, ErrorResponse } from '@gh-trend-tracker/shared';
-import type { Bindings } from '../types/bindings';
+import type { AppEnv } from '../types/app';
 
-const repositories = new Hono<{ Bindings: Bindings }>();
+const repositories = new Hono<AppEnv>();
 
 // リポジトリの履歴データ
 repositories.get('/:repoId/history', async (c) => {
@@ -17,7 +16,7 @@ repositories.get('/:repoId/history', async (c) => {
     return c.json(errorResponse, 400);
   }
 
-  const db = drizzle(c.env.DB);
+  const db = c.get('db');
 
   try {
     const history = await getRepositoryHistory(db, repoId, DEFAULT_HISTORY_DAYS);

--- a/apps/backend/src/routes/trends.ts
+++ b/apps/backend/src/routes/trends.ts
@@ -1,15 +1,14 @@
 import { Hono } from 'hono';
-import { drizzle } from 'drizzle-orm/d1';
 import { getTrendsByLanguage, getAllTrends } from '../shared/queries';
 import { DEFAULT_TREND_LIMIT } from '../shared/constants';
 import type { TrendsResponse, ErrorResponse } from '@gh-trend-tracker/shared';
-import type { Bindings } from '../types/bindings';
+import type { AppEnv } from '../types/app';
 
-const trends = new Hono<{ Bindings: Bindings }>();
+const trends = new Hono<AppEnv>();
 
 // 全言語のトレンド
 trends.get('/', async (c) => {
-  const db = drizzle(c.env.DB);
+  const db = c.get('db');
 
   try {
     const trendsList = await getAllTrends(db, DEFAULT_TREND_LIMIT);
@@ -25,7 +24,7 @@ trends.get('/', async (c) => {
 // 言語別トレンド
 trends.get('/:language', async (c) => {
   const language = c.req.param('language');
-  const db = drizzle(c.env.DB);
+  const db = c.get('db');
 
   try {
     const trendsList = await getTrendsByLanguage(db, language, DEFAULT_TREND_LIMIT);

--- a/apps/backend/src/types/app.ts
+++ b/apps/backend/src/types/app.ts
@@ -1,0 +1,14 @@
+/**
+ * Honoアプリケーション共通型定義
+ */
+import type { DrizzleD1Database } from 'drizzle-orm/d1';
+import type { Bindings } from './bindings';
+
+export type Variables = {
+  db: DrizzleD1Database;
+};
+
+export type AppEnv = {
+  Bindings: Bindings;
+  Variables: Variables;
+};


### PR DESCRIPTION
## Summary
- ミドルウェアでDrizzleインスタンスを一度だけ初期化し、コンテキストに保存するように変更
- 各ルートハンドラで`drizzle(c.env.DB)`を呼び出す代わりに`c.get('db')`で取得するように変更
- `AppEnv`型を追加し、全ルートハンドラで共通の型定義を使用

## Changes
- `apps/backend/src/middleware/database.ts` - 新規追加: データベースミドルウェア
- `apps/backend/src/types/app.ts` - 新規追加: Honoアプリケーション共通型定義
- `apps/backend/src/index.ts` - ミドルウェア適用
- `apps/backend/src/routes/*.ts` - 全ルートハンドラをc.get('db')経由に変更

## Test plan
- [x] 型チェック通過
- [x] 既存テスト通過
- [x] ESLint通過

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)