### PR TITLE
refactor: migrate data collection scripts to Drizzle ORM

### DIFF
--- a/apps/backend/scripts/collect-data.ts
+++ b/apps/backend/scripts/collect-data.ts
@@ -1,14 +1,14 @@
 #!/usr/bin/env tsx
 
 /**
- * GitHub Trends Data Collection Script
+ * GitHubトレンドデータ収集スクリプト
  *
- * Fetches trending repositories from GitHub API and stores them in D1 database
+ * GitHub APIからトレンドリポジトリを取得し、D1データベースに保存する
  *
- * Usage:
- *   npm run collect              # Default: local database
- *   npm run collect -- --remote  # Use remote D1 database
- *   npm run collect -- --dry-run # Fetch only, don't save to DB
+ * 使用方法:
+ *   npm run collect              # デフォルト: ローカルデータベース
+ *   npm run collect -- --remote  # リモートD1データベースを使用
+ *   npm run collect -- --dry-run # 取得のみ、DBへの保存はしない
  */
 
 import { GitHubClient } from './lib/github-client.js';
@@ -16,7 +16,7 @@ import { DatabaseManager } from './lib/db-manager.js';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 
-// Target languages for MVP
+// MVP対象言語
 const TARGET_LANGUAGES = [
   'TypeScript',
   'JavaScript',
@@ -30,7 +30,7 @@ const TARGET_LANGUAGES = [
   'Swift',
 ];
 
-// Configuration
+// 設定
 const REPOS_PER_LANGUAGE = 50;
 const DATABASE_NAME = 'gh-trends-db';
 
@@ -40,7 +40,7 @@ interface CommandArgs {
 }
 
 /**
- * Parse command line arguments
+ * コマンドライン引数をパース
  */
 function parseArgs(): CommandArgs {
   const args = process.argv.slice(2);
@@ -51,10 +51,10 @@ function parseArgs(): CommandArgs {
 }
 
 /**
- * Load environment variables
+ * 環境変数を読み込み
  */
 function loadEnv(): { githubToken: string } {
-  // Try to load from .env file
+  // .envファイルから読み込みを試行
   try {
     const envPath = join(process.cwd(), '.env');
 
@@ -77,14 +77,14 @@ function loadEnv(): { githubToken: string } {
       }
     }
   } catch (error) {
-    console.warn('Could not load .env file:', error);
+    console.warn('.envファイルの読み込みに失敗:', error);
   }
 
   const githubToken = process.env.GITHUB_TOKEN;
 
   if (!githubToken) {
     throw new Error(
-      'GITHUB_TOKEN environment variable is required. Please set it in backend/.env file.'
+      'GITHUB_TOKEN環境変数が必要です。backend/.envファイルに設定してください。'
     );
   }
 
@@ -92,25 +92,25 @@ function loadEnv(): { githubToken: string } {
 }
 
 /**
- * Main execution function
+ * メイン実行関数
  */
 async function main() {
-  console.log('=== GitHub Trends Data Collection ===\n');
+  console.log('=== GitHubトレンドデータ収集 ===\n');
 
-  // Parse arguments
+  // 引数をパース
   const args = parseArgs();
-  console.log(`Mode: ${args.dryRun ? 'DRY RUN' : args.useRemote ? 'REMOTE' : 'LOCAL'}\n`);
+  console.log(`モード: ${args.dryRun ? 'DRY RUN' : args.useRemote ? 'REMOTE' : 'LOCAL'}\n`);
 
-  // Load environment
+  // 環境変数を読み込み
   const { githubToken } = loadEnv();
-  console.log('✓ Environment loaded\n');
+  console.log('✓ 環境変数を読み込み完了\n');
 
-  // Initialize GitHub client
+  // GitHubクライアントを初期化
   const githubClient = new GitHubClient(githubToken);
-  console.log('✓ GitHub client initialized\n');
+  console.log('✓ GitHubクライアントを初期化完了\n');
 
-  // Fetch repositories
-  console.log(`Fetching trending repositories (${REPOS_PER_LANGUAGE} per language)...\n`);
+  // リポジトリを取得
+  console.log(`トレンドリポジトリを取得中（各言語${REPOS_PER_LANGUAGE}件）...\n`);
   const startTime = Date.now();
 
   const reposByLanguage = await githubClient.fetchMultipleLanguages(
@@ -119,9 +119,9 @@ async function main() {
   );
 
   const fetchDuration = ((Date.now() - startTime) / 1000).toFixed(2);
-  console.log(`\n✓ Fetching completed in ${fetchDuration}s\n`);
+  console.log(`\n✓ 取得完了（${fetchDuration}秒）\n`);
 
-  // Calculate totals
+  // 合計を計算
   let totalRepos = 0;
   let successfulLanguages = 0;
 
@@ -132,54 +132,62 @@ async function main() {
     }
   }
 
-  console.log(`Summary:`);
-  console.log(`  - Total repos fetched: ${totalRepos}`);
-  console.log(`  - Successful languages: ${successfulLanguages}/${TARGET_LANGUAGES.length}\n`);
+  console.log(`サマリー:`);
+  console.log(`  - 取得リポジトリ数: ${totalRepos}`);
+  console.log(`  - 成功した言語数: ${successfulLanguages}/${TARGET_LANGUAGES.length}\n`);
 
-  // Save to database (unless dry run)
+  // データベースに保存（dry runでない場合）
   if (args.dryRun) {
-    console.log('Dry run mode - skipping database writes.');
-    console.log('\nRepos by language:');
+    console.log('Dry runモード - データベースへの書き込みをスキップ');
+    console.log('\n言語別リポジトリ数:');
     for (const [language, repos] of reposByLanguage.entries()) {
-      console.log(`  ${language}: ${repos.length} repos`);
+      console.log(`  ${language}: ${repos.length}件`);
     }
     return;
   }
 
-  // Initialize database manager
+  // Drizzle ORMでデータベースマネージャーを初期化
   const dbManager = new DatabaseManager({
     databaseName: DATABASE_NAME,
     useRemote: args.useRemote,
   });
-  console.log(`✓ Database manager initialized (${args.useRemote ? 'remote' : 'local'})\n`);
 
-  // Save to database
-  console.log('Saving to database...\n');
-  const saveStartTime = Date.now();
+  try {
+    console.log('データベース接続を初期化中...');
+    await dbManager.initialize();
+    console.log(`✓ データベースマネージャーを初期化完了（${args.useRemote ? 'リモート' : 'ローカル'}）\n`);
 
-  const saveResult = await dbManager.saveReposByLanguage(reposByLanguage);
+    // データベースに保存
+    console.log('データベースに保存中...\n');
+    const saveStartTime = Date.now();
 
-  const saveDuration = ((Date.now() - saveStartTime) / 1000).toFixed(2);
-  console.log(`\n✓ Database save completed in ${saveDuration}s\n`);
+    const saveResult = await dbManager.saveReposByLanguage(reposByLanguage);
 
-  // Final summary
-  console.log('=== Final Summary ===');
-  console.log(`Fetched: ${totalRepos} repos`);
-  console.log(`Saved: ${saveResult.totalSuccess} repos`);
-  console.log(`Failed: ${saveResult.totalFailed} repos`);
+    const saveDuration = ((Date.now() - saveStartTime) / 1000).toFixed(2);
+    console.log(`\n✓ データベース保存完了（${saveDuration}秒）\n`);
 
-  if (saveResult.errors.length > 0) {
-    console.log(`\nErrors (showing first 5):`);
-    saveResult.errors.slice(0, 5).forEach((error) => {
-      console.log(`  - ${error}`);
-    });
+    // 最終サマリー
+    console.log('=== 最終サマリー ===');
+    console.log(`取得: ${totalRepos}件`);
+    console.log(`保存成功: ${saveResult.totalSuccess}件`);
+    console.log(`保存失敗: ${saveResult.totalFailed}件`);
+
+    if (saveResult.errors.length > 0) {
+      console.log(`\nエラー（最初の5件）:`);
+      saveResult.errors.slice(0, 5).forEach((error) => {
+        console.log(`  - ${error}`);
+      });
+    }
+
+    console.log('\n✓ データ収集完了！');
+  } finally {
+    // データベース接続をクリーンアップ
+    await dbManager.dispose();
   }
-
-  console.log('\n✓ Data collection complete!');
 }
 
-// Execute
+// 実行
 main().catch((error) => {
-  console.error('\n✗ Fatal error:', error);
+  console.error('\n✗ 致命的エラー:', error);
   process.exit(1);
 });

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "deploy:backend": "npm run deploy -w apps/backend",
     "deploy:frontend": "npm run deploy -w apps/frontend",
     "test:backend": "npm run test -w apps/backend",
+    "collect": "npm run collect -w apps/backend",
     "test": "npm run test --workspaces --if-present",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
## Summary
- 手動SQL生成を廃止し、Drizzle ORMのパラメータ化クエリを使用
- wranglerのgetPlatformProxyを使用してCLIスクリプトからD1に接続
- SQLインジェクションリスクを排除し、コードの保守性を向上

## Changes
### db-manager.ts
- `escapeSql`と手動SQLテンプレート生成を削除
- `writeFileSync` + `execSync`アプローチを廃止
- Drizzle ORMの`insert().values().onConflictDoUpdate()`を使用
- `initialize()`/`dispose()`ライフサイクルメソッドを追加

### collect-data.ts
- DatabaseManagerの初期化とクリーンアップを適切に呼び出すよう更新
- try/finallyパターンでリソースの確実な解放を保証

## Test plan
- [x] TypeScript型チェック通過（`npm run type-check`）
- [x] ESLintチェック通過（`npm run lint`）
- [x] テスト通過（`npm run test`）
- [ ] ローカルD1でデータ収集を実行（`npm run collect`）
- [ ] リモートD1でデータ収集を実行（`npm run collect -- --remote`）

Closes #11