### PR TITLE
perf: LanguageFilterをAstro View Transitionsに移行

### DIFF
--- a/apps/frontend/src/components/LanguageFilter.tsx
+++ b/apps/frontend/src/components/LanguageFilter.tsx
@@ -2,6 +2,7 @@
  * LanguageFilter Component
  * Dropdown to filter repositories by programming language
  */
+import { navigate } from 'astro:transitions/client';
 
 interface Props {
   languages: (string | null)[];
@@ -12,12 +13,9 @@ export default function LanguageFilter({ languages, currentLanguage }: Props) {
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const language = e.target.value;
 
-    // Reload page with language parameter
-    if (language === '') {
-      window.location.href = '/';
-    } else {
-      window.location.href = `/?language=${encodeURIComponent(language)}`;
-    }
+    // Navigate with soft navigation using Astro View Transitions
+    const url = language ? `/?language=${encodeURIComponent(language)}` : '/';
+    navigate(url);
   };
 
   // Filter out null languages and sort

--- a/apps/frontend/src/layouts/Layout.astro
+++ b/apps/frontend/src/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import { ViewTransitions } from 'astro:transitions';
 import '../styles/global.css';
 
 interface Props {
@@ -16,6 +17,7 @@ const { title } = Astro.props;
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>{title}</title>
+    <ViewTransitions />
   </head>
   <body>
     <slot />


### PR DESCRIPTION
## Summary
- `LanguageFilter`コンポーネントで`window.location.href`による ハードナビゲーションを、Astro View Transitionsの`navigate`関数を使用したソフトナビゲーションに変更
- `Layout.astro`に`<ViewTransitions />`コンポーネントを追加

## Changes
- `apps/frontend/src/layouts/Layout.astro`: ViewTransitionsコンポーネントを追加
- `apps/frontend/src/components/LanguageFilter.tsx`: navigate関数を使用するよう変更

## Benefits
- ページ全体のリロードを回避
- スクロール位置の保持
- スムーズなページ遷移アニメーション
- UXとパフォーマンスの向上

## Test plan
- [ ] 言語フィルターで言語を選択した際、ページ全体がリロードされないことを確認
- [ ] スクロール位置が保持されることを確認
- [ ] 「All Languages」に戻した際も同様にソフトナビゲーションされることを確認
- [ ] ビルドが正常に完了することを確認

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)