### PR TITLE
feat: OpenAPI仕様書に準拠したエラーハンドリングを実装

### DIFF
--- a/apps/backend/src/routes/languages.ts
+++ b/apps/backend/src/routes/languages.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { getAllLanguages } from '../shared/queries';
-import type { LanguagesResponse, ErrorResponse } from '@gh-trend-tracker/shared';
+import { dbError } from '../shared/errors';
+import type { LanguagesResponse, ApiError } from '@gh-trend-tracker/shared';
 import type { AppEnv } from '../types/app';
 
 const languages = new Hono<AppEnv>();
@@ -15,7 +16,7 @@ languages.get('/', async (c) => {
     return c.json(response);
   } catch (error) {
     console.error('Error fetching languages:', error);
-    const errorResponse: ErrorResponse = { error: 'Failed to fetch languages' };
+    const errorResponse: ApiError = dbError('Failed to fetch languages');
     return c.json(errorResponse, 500);
   }
 });

--- a/apps/backend/src/routes/trends.ts
+++ b/apps/backend/src/routes/trends.ts
@@ -1,7 +1,8 @@
 import { Hono } from 'hono';
 import { getTrendsByLanguage, getAllTrends } from '../shared/queries';
 import { DEFAULT_TREND_LIMIT } from '../shared/constants';
-import type { TrendsResponse, ErrorResponse } from '@gh-trend-tracker/shared';
+import { dbError } from '../shared/errors';
+import type { TrendsResponse, ApiError } from '@gh-trend-tracker/shared';
 import type { AppEnv } from '../types/app';
 
 const trends = new Hono<AppEnv>();
@@ -16,7 +17,7 @@ trends.get('/', async (c) => {
     return c.json(response);
   } catch (error) {
     console.error('Error fetching trends:', error);
-    const errorResponse: ErrorResponse = { error: 'Failed to fetch trends' };
+    const errorResponse: ApiError = dbError('Failed to fetch trends');
     return c.json(errorResponse, 500);
   }
 });
@@ -32,7 +33,7 @@ trends.get('/:language', async (c) => {
     return c.json(response);
   } catch (error) {
     console.error('Error fetching trends:', error);
-    const errorResponse: ErrorResponse = { error: 'Failed to fetch trends' };
+    const errorResponse: ApiError = dbError('Failed to fetch trends');
     return c.json(errorResponse, 500);
   }
 });

--- a/apps/backend/src/shared/errors.ts
+++ b/apps/backend/src/shared/errors.ts
@@ -1,0 +1,55 @@
+/**
+ * エラーハンドリングユーティリティ
+ * OpenAPI仕様書に準拠したエラーレスポンスを生成する
+ */
+import type { ApiError, ErrorCode } from '@gh-trend-tracker/shared';
+
+/**
+ * トレースIDを生成する
+ */
+function generateTraceId(): string {
+  return crypto.randomUUID();
+}
+
+/**
+ * OpenAPI準拠のエラーレスポンスを生成する
+ */
+export function createApiError(
+  message: string,
+  code: ErrorCode,
+  traceId?: string
+): ApiError {
+  return {
+    error: message,
+    code,
+    traceId: traceId ?? generateTraceId(),
+  };
+}
+
+/**
+ * バリデーションエラーを生成する
+ */
+export function validationError(message: string, traceId?: string): ApiError {
+  return createApiError(message, 'VALIDATION_ERROR', traceId);
+}
+
+/**
+ * Not Foundエラーを生成する
+ */
+export function notFoundError(message: string, traceId?: string): ApiError {
+  return createApiError(message, 'NOT_FOUND', traceId);
+}
+
+/**
+ * データベースエラーを生成する
+ */
+export function dbError(message: string, traceId?: string): ApiError {
+  return createApiError(message, 'DB_ERROR', traceId);
+}
+
+/**
+ * 内部エラーを生成する
+ */
+export function internalError(message: string, traceId?: string): ApiError {
+  return createApiError(message, 'INTERNAL_ERROR', traceId);
+}


### PR DESCRIPTION
## Summary

- OpenAPI仕様書（`openapi.yaml`）で定義されたエラースキーマに準拠し、全エンドポイントでエラーレスポンスに`code`と`traceId`を付与
- 新規エラーヘルパー関数を作成し、一貫したエラーレスポンス生成を実現

## Changes

### 新規ファイル
- `apps/backend/src/shared/errors.ts`
  - `createApiError()`: ベースヘルパー
  - `validationError()`: 400 Bad Request用
  - `notFoundError()`: 404 Not Found用
  - `dbError()`: 500 DB Error用
  - `internalError()`: 500 Internal Error用
  - `generateTraceId()`: crypto.randomUUIDでtraceID生成

### 更新ファイル
- `apps/backend/src/routes/trends.ts`: DB エラーに `code` と `traceId` を追加
- `apps/backend/src/routes/repositories.ts`: バリデーション/NotFound/DB エラーに対応
- `apps/backend/src/routes/languages.ts`: DB エラーに `code` と `traceId` を追加

## Test plan

- [x] テスト実行済み（`npm run test:backend` - 1 passed）
- [x] 型チェック通過（`npm run type-check`）
- [x] Lint通過（`npm run lint`）

Closes #31

🤖 Generated with [Claude Code](https://claude.ai/code)