### PR TITLE
feat: リポジトリ詳細ページを実装

### DIFF
--- a/apps/backend/src/routes/repositories.ts
+++ b/apps/backend/src/routes/repositories.ts
@@ -1,12 +1,40 @@
 import { Hono } from 'hono';
-import { getRepositoryHistory } from '../shared/queries';
+import { getRepositoryHistory, getRepositoryDetail } from '../shared/queries';
 import { DEFAULT_HISTORY_DAYS } from '../shared/constants';
 import { parsePositiveInt } from '../shared/utils';
 import { validationError, notFoundError, dbError } from '../shared/errors';
-import type { HistoryResponse, ApiError } from '@gh-trend-tracker/shared';
+import type { HistoryResponse, RepoDetailResponse, ApiError } from '@gh-trend-tracker/shared';
 import type { AppEnv } from '../types/app';
 
 const repositories = new Hono<AppEnv>();
+
+// リポジトリの詳細情報
+repositories.get('/:repoId', async (c) => {
+  const repoId = parsePositiveInt(c.req.param('repoId'));
+
+  if (repoId === null) {
+    const errorResponse: ApiError = validationError('Invalid repoId: must be a positive integer');
+    return c.json(errorResponse, 400);
+  }
+
+  const db = c.get('db');
+
+  try {
+    const detail = await getRepositoryDetail(db, repoId);
+
+    if (!detail) {
+      const errorResponse: ApiError = notFoundError('Repository not found');
+      return c.json(errorResponse, 404);
+    }
+
+    const response: RepoDetailResponse = detail;
+    return c.json(response);
+  } catch (error) {
+    console.error('Error fetching repository detail:', error);
+    const errorResponse: ApiError = dbError('Failed to fetch repository detail');
+    return c.json(errorResponse, 500);
+  }
+});
 
 // リポジトリの履歴データ
 repositories.get('/:repoId/history', async (c) => {

--- a/apps/frontend/src/components/RepoDetail.tsx
+++ b/apps/frontend/src/components/RepoDetail.tsx
@@ -1,0 +1,121 @@
+/**
+ * RepoDetail Component
+ * Displays detailed repository information with stats and star history chart
+ */
+
+import React from 'react';
+import type { RepoDetailResponse } from '@gh-trend-tracker/shared';
+import StarChart from './StarChart';
+
+interface ChartData {
+  date: string;
+  stars: number;
+}
+
+interface Props {
+  detail: RepoDetailResponse;
+  history: ChartData[];
+}
+
+function formatGrowthRate(rate: number | null): string {
+  if (rate === null) return '-';
+  const sign = rate >= 0 ? '+' : '';
+  return `${sign}${rate.toFixed(2)}%`;
+}
+
+function formatGrowth(growth: number | null): string {
+  if (growth === null) return '-';
+  const sign = growth >= 0 ? '+' : '';
+  return `${sign}${growth.toLocaleString()}`;
+}
+
+function getGrowthClass(rate: number | null): string {
+  if (rate === null) return 'growth-neutral';
+  if (rate >= 5) return 'growth-high';
+  if (rate >= 1) return 'growth-medium';
+  return 'growth-low';
+}
+
+export default function RepoDetail({ detail, history }: Props) {
+  const { repository, currentStats, weeklyGrowth, weeklyGrowthRate } = detail;
+
+  return (
+    <div className="repo-detail">
+      <header className="repo-header">
+        <h1>
+          <a
+            href={repository.htmlUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {repository.fullName}
+          </a>
+        </h1>
+        {repository.description && (
+          <p className="repo-description">{repository.description}</p>
+        )}
+        <div className="repo-meta">
+          {repository.language && (
+            <span className="language-badge">{repository.language}</span>
+          )}
+          {repository.homepage && (
+            <a
+              href={repository.homepage}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="homepage-link"
+            >
+              Homepage
+            </a>
+          )}
+        </div>
+        {repository.topics.length > 0 && (
+          <div className="topics">
+            {repository.topics.map((topic) => (
+              <span key={topic} className="topic-badge">
+                {topic}
+              </span>
+            ))}
+          </div>
+        )}
+      </header>
+
+      <section className="repo-stats">
+        <h2>Current Stats</h2>
+        {currentStats ? (
+          <div className="stats-grid">
+            <div className="stat-item">
+              <span className="stat-value">{currentStats.stars.toLocaleString()}</span>
+              <span className="stat-label">Stars</span>
+            </div>
+            <div className="stat-item">
+              <span className="stat-value">{currentStats.forks.toLocaleString()}</span>
+              <span className="stat-label">Forks</span>
+            </div>
+            <div className="stat-item">
+              <span className="stat-value">{currentStats.watchers.toLocaleString()}</span>
+              <span className="stat-label">Watchers</span>
+            </div>
+            <div className="stat-item">
+              <span className="stat-value">{currentStats.openIssues.toLocaleString()}</span>
+              <span className="stat-label">Open Issues</span>
+            </div>
+            <div className={`stat-item ${getGrowthClass(weeklyGrowthRate)}`}>
+              <span className="stat-value">
+                {formatGrowth(weeklyGrowth)} ({formatGrowthRate(weeklyGrowthRate)})
+              </span>
+              <span className="stat-label">Weekly Growth</span>
+            </div>
+          </div>
+        ) : (
+          <p className="no-stats">No statistics available</p>
+        )}
+      </section>
+
+      <section className="repo-chart">
+        <h2>Star History (Last 90 Days)</h2>
+        <StarChart data={history} />
+      </section>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/TrendList.tsx
+++ b/apps/frontend/src/components/TrendList.tsx
@@ -97,12 +97,20 @@ export default function TrendList({ initialTrends }: Props) {
               >
                 <td>
                   <a
+                    href={`/repo/${trend.repoId}`}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    {trend.fullName}
+                  </a>
+                  <a
                     href={trend.htmlUrl}
                     target="_blank"
                     rel="noopener noreferrer"
                     onClick={(e) => e.stopPropagation()}
+                    className="external-link"
+                    title="Open on GitHub"
                   >
-                    {trend.fullName}
+                    ↗
                   </a>
                 </td>
                 <td>

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -3,7 +3,12 @@
  * Fetches data from the backend API
  */
 
-import type { TrendsResponse, LanguagesResponse, HistoryResponse } from '@gh-trend-tracker/shared';
+import type {
+  TrendsResponse,
+  LanguagesResponse,
+  HistoryResponse,
+  RepoDetailResponse,
+} from '@gh-trend-tracker/shared';
 
 const API_BASE = import.meta.env.PUBLIC_API_URL || 'http://localhost:8787';
 
@@ -54,6 +59,23 @@ export async function getRepoHistory(repoId: number): Promise<HistoryResponse> {
 
   if (!response.ok) {
     throw new Error(`Failed to fetch history: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Fetch repository detail
+ * @param repoId - GitHub repository ID
+ * @returns RepoDetailResponse with repository info and stats
+ */
+export async function getRepoDetail(repoId: number): Promise<RepoDetailResponse> {
+  const url = `${API_BASE}/api/repos/${repoId}`;
+
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch repository detail: ${response.status} ${response.statusText}`);
   }
 
   return response.json();

--- a/apps/frontend/src/pages/repo/[repoId].astro
+++ b/apps/frontend/src/pages/repo/[repoId].astro
@@ -1,0 +1,81 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import RepoDetail from '../../components/RepoDetail';
+import { getTrends, getRepoDetail, getRepoHistory } from '../../lib/api';
+import type { RepoDetailResponse, RepoSnapshot } from '@gh-trend-tracker/shared';
+
+export async function getStaticPaths() {
+  try {
+    const trendsData = await getTrends();
+    const paths = trendsData.trends.map((trend) => ({
+      params: { repoId: String(trend.repoId) },
+    }));
+    return paths;
+  } catch (e) {
+    console.error('Failed to generate static paths:', e);
+    return [];
+  }
+}
+
+// Get repoId from URL parameter
+const { repoId } = Astro.params;
+
+let detail: RepoDetailResponse | null = null;
+let history: { date: string; stars: number }[] = [];
+let error: string | null = null;
+
+if (!repoId || isNaN(Number(repoId))) {
+  error = 'Invalid repository ID';
+} else {
+  try {
+    const repoIdNum = Number(repoId);
+    detail = await getRepoDetail(repoIdNum);
+
+    const historyData = await getRepoHistory(repoIdNum);
+    history = historyData.history
+      .map((snapshot: RepoSnapshot) => ({
+        date: snapshot.snapshotDate,
+        stars: snapshot.stars,
+      }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+  } catch (e) {
+    error = e instanceof Error ? e.message : 'Failed to load repository';
+    console.error('Failed to fetch repository:', e);
+  }
+}
+
+const title = detail?.repository.fullName
+  ? `${detail.repository.fullName} - GitHub Trends Tracker`
+  : 'Repository - GitHub Trends Tracker';
+---
+
+<Layout title={title}>
+  <div class="container">
+    <nav class="breadcrumb">
+      <a href="/">Home</a> &gt; Repository Details
+    </nav>
+
+    {error ? (
+      <div class="error">
+        <strong>Error:</strong> {error}
+        <br /><br />
+        <a href="/">Back to Home</a>
+      </div>
+    ) : detail ? (
+      <RepoDetail detail={detail} history={history} client:load />
+    ) : (
+      <div class="loading">Loading...</div>
+    )}
+  </div>
+</Layout>
+
+<style>
+  .breadcrumb {
+    margin-bottom: 1.5rem;
+    font-size: 0.875rem;
+    color: #586069;
+  }
+  .breadcrumb a {
+    color: #0366d6;
+  }
+</style>

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -75,6 +75,16 @@ td:first-child {
   font-weight: 500;
 }
 
+.external-link {
+  margin-left: 0.5rem;
+  opacity: 0.5;
+  font-size: 0.875rem;
+}
+
+.external-link:hover {
+  opacity: 1;
+}
+
 /* Links */
 a {
   color: #0366d6;
@@ -216,6 +226,122 @@ input:focus {
 
 .star-chart-error {
   color: #c53030;
+}
+
+/* Repository Detail Page */
+.repo-detail {
+  max-width: 900px;
+}
+
+.repo-header {
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid #e1e4e8;
+}
+
+.repo-header h1 {
+  margin-bottom: 0.5rem;
+}
+
+.repo-header h1 a {
+  color: #24292e;
+}
+
+.repo-header h1 a:hover {
+  color: #0366d6;
+}
+
+.repo-description {
+  color: #586069;
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+}
+
+.repo-meta {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.homepage-link {
+  font-size: 0.875rem;
+}
+
+.topics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.topic-badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  background: #f1f8ff;
+  color: #0366d6;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.repo-stats {
+  margin-bottom: 2rem;
+}
+
+.repo-stats h2 {
+  margin-top: 0;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.stat-item {
+  background: #f6f8fa;
+  padding: 1rem;
+  border-radius: 8px;
+  text-align: center;
+}
+
+.stat-value {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #24292e;
+}
+
+.stat-label {
+  display: block;
+  font-size: 0.875rem;
+  color: #586069;
+  margin-top: 0.25rem;
+}
+
+.stat-item.growth-high .stat-value {
+  color: #22863a;
+}
+
+.stat-item.growth-medium .stat-value {
+  color: #b08800;
+}
+
+.stat-item.growth-low .stat-value {
+  color: #586069;
+}
+
+.no-stats {
+  color: #586069;
+  font-style: italic;
+}
+
+.repo-chart {
+  margin-bottom: 2rem;
+}
+
+.repo-chart h2 {
+  margin-top: 0;
 }
 
 /* Responsive */

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -54,6 +54,30 @@ export interface HistoryResponse {
   history: RepoSnapshot[];
 }
 
+// リポジトリ詳細レスポンス型
+export interface RepoDetailResponse {
+  repository: {
+    repoId: number;
+    name: string;
+    fullName: string;
+    owner: string;
+    language: string | null;
+    description: string | null;
+    htmlUrl: string;
+    homepage: string | null;
+    topics: string[];
+  };
+  currentStats: {
+    stars: number;
+    forks: number;
+    watchers: number;
+    openIssues: number;
+    snapshotDate: string;
+  } | null;
+  weeklyGrowth: number | null;
+  weeklyGrowthRate: number | null;
+}
+
 export interface LanguagesResponse {
   languages: (string | null)[];
 }


### PR DESCRIPTION
## Summary

- 個別リポジトリの詳細情報と履歴を表示する専用ページ `/repo/:repoId` を追加
- バックエンドに `GET /api/repos/:repoId` エンドポイントを追加
- トレンドリストからリポジトリ詳細ページへのリンクを追加

## Test plan

- [x] バックエンド型チェック通過
- [x] バックエンドLint通過
- [x] フロントエンドビルド成功（101ページ生成）
- [x] バックエンドテスト通過

## Changes

### Backend
- `apps/backend/src/routes/repositories.ts`: `GET /:repoId` エンドポイントを追加
- `apps/backend/src/shared/queries.ts`: `getRepositoryDetail` クエリ関数を追加

### Frontend
- `apps/frontend/src/pages/repo/[repoId].astro`: 詳細ページを追加
- `apps/frontend/src/components/RepoDetail.tsx`: 詳細表示コンポーネントを作成
- `apps/frontend/src/components/TrendList.tsx`: 詳細ページへのリンクを追加
- `apps/frontend/src/lib/api.ts`: `getRepoDetail` API関数を追加
- `apps/frontend/src/styles/global.css`: 詳細ページ用スタイルを追加

### Shared
- `shared/src/index.ts`: `RepoDetailResponse` 型を追加

## 表示内容

1. **基本情報**: リポジトリ名、オーナー、説明、言語、トピックス、GitHubリンク
2. **現在の指標**: スター数、フォーク数、ウォッチャー数、オープンIssue数
3. **週間増加率**: 過去7日間のスター増加数と増加率（色分け表示）
4. **履歴グラフ**: 過去90日間のスター推移（Rechartsライングラフ）

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)