### PR TITLE
feat(db): add metrics_daily and languages tables

### DIFF
--- a/apps/backend/schema/schema.sql
+++ b/apps/backend/schema/schema.sql
@@ -29,8 +29,38 @@ CREATE TABLE IF NOT EXISTS repo_snapshots (
   UNIQUE(repo_id, snapshot_date)  -- One snapshot per repo per day
 );
 
+-- Daily metrics (pre-calculated star growth)
+CREATE TABLE IF NOT EXISTS metrics_daily (
+  repo_id INTEGER NOT NULL,
+  calculated_date TEXT NOT NULL,
+  stars_7d_increase INTEGER NOT NULL DEFAULT 0,
+  stars_30d_increase INTEGER NOT NULL DEFAULT 0,
+  stars_7d_rate REAL NOT NULL DEFAULT 0.0,
+  stars_30d_rate REAL NOT NULL DEFAULT 0.0,
+  PRIMARY KEY (repo_id, calculated_date),
+  FOREIGN KEY (repo_id) REFERENCES repositories(repo_id) ON DELETE CASCADE
+);
+
+-- Language master data
+CREATE TABLE IF NOT EXISTS languages (
+  code TEXT PRIMARY KEY NOT NULL,
+  name_ja TEXT NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 100
+);
+
+-- Initial language data
+INSERT OR IGNORE INTO languages (code, name_ja, sort_order) VALUES
+  ('all', 'すべて', 0),
+  ('TypeScript', 'TypeScript', 1),
+  ('Python', 'Python', 2),
+  ('JavaScript', 'JavaScript', 3),
+  ('Go', 'Go', 4),
+  ('Rust', 'Rust', 5),
+  ('Java', 'Java', 6);
+
 -- Indexes for performance
 CREATE INDEX IF NOT EXISTS idx_repos_language ON repositories(language);
 CREATE INDEX IF NOT EXISTS idx_repos_updated ON repositories(updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_snapshots_date ON repo_snapshots(snapshot_date DESC);
 CREATE INDEX IF NOT EXISTS idx_snapshots_repo ON repo_snapshots(repo_id, snapshot_date DESC);
+CREATE INDEX IF NOT EXISTS idx_metrics_date ON metrics_daily(calculated_date DESC);

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -1,4 +1,11 @@
-import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+import {
+  sqliteTable,
+  text,
+  integer,
+  real,
+  index,
+  primaryKey,
+} from 'drizzle-orm/sqlite-core';
 import { sql } from 'drizzle-orm';
 
 export const repositories = sqliteTable(
@@ -44,7 +51,33 @@ export const repoSnapshots = sqliteTable(
   })
 );
 
+export const metricsDaily = sqliteTable(
+  'metrics_daily',
+  {
+    repoId: integer('repo_id').notNull(),
+    calculatedDate: text('calculated_date').notNull(),
+    stars7dIncrease: integer('stars_7d_increase').notNull().default(0),
+    stars30dIncrease: integer('stars_30d_increase').notNull().default(0),
+    stars7dRate: real('stars_7d_rate').notNull().default(0.0),
+    stars30dRate: real('stars_30d_rate').notNull().default(0.0),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.repoId, table.calculatedDate] }),
+    dateIdx: index('idx_metrics_date').on(table.calculatedDate),
+  })
+);
+
+export const languages = sqliteTable('languages', {
+  code: text('code').primaryKey().notNull(),
+  nameJa: text('name_ja').notNull(),
+  sortOrder: integer('sort_order').notNull().default(100),
+});
+
 export type Repository = typeof repositories.$inferSelect;
 export type NewRepository = typeof repositories.$inferInsert;
 export type RepoSnapshot = typeof repoSnapshots.$inferSelect;
 export type NewRepoSnapshot = typeof repoSnapshots.$inferInsert;
+export type MetricsDaily = typeof metricsDaily.$inferSelect;
+export type NewMetricsDaily = typeof metricsDaily.$inferInsert;
+export type Language = typeof languages.$inferSelect;
+export type NewLanguage = typeof languages.$inferInsert;


### PR DESCRIPTION
## Summary

- Add `metrics_daily` table for pre-calculated star growth (7d/30d increase and rate)
- Add `languages` table as master data with initial language entries
- Update Drizzle ORM schema with corresponding TypeScript definitions
- Add index on `metrics_daily.calculated_date` for performance

## Changes

### New Tables

**metrics_daily (tab-MET)**
| Column | Type | Description |
|--------|------|-------------|
| repo_id | INTEGER | Primary key (composite with calculated_date) |
| calculated_date | TEXT | ISO date string (YYYY-MM-DD) |
| stars_7d_increase | INTEGER | 7-day star increase count |
| stars_30d_increase | INTEGER | 30-day star increase count |
| stars_7d_rate | REAL | 7-day star increase rate |
| stars_30d_rate | REAL | 30-day star increase rate |

**languages (tab-LNG)**
| Column | Type | Description |
|--------|------|-------------|
| code | TEXT | Primary key, language code |
| name_ja | TEXT | Japanese display name |
| sort_order | INTEGER | Display order in UI |

### Initial Language Data
- all (すべて)
- TypeScript, Python, JavaScript, Go, Rust, Java

## Test Plan

- [x] schema.sql and schema.ts are synchronized
- [x] Local D1 migration successful
- [x] TypeScript type check passed
- [x] ESLint passed
- [x] All tests passed

## Related Requirements

- fun-004: 7日間スター増加数の表示
- fun-005: 30日間スター増加数の表示
- fun-006: 言語選択UI提供
- fun-027: 7日間/30日間スター増加数/率の計算ロジック実行
- fun-028: 計算済み増加率のDB保存

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)