### PR TITLE
feat(shared): 型定義・共有モジュール整備

### DIFF
--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -2,170 +2,29 @@
  * API/Frontend間で共有される型定義
  */
 
-// Repository型（データベーススキーマから派生）
-export interface Repository {
-  repoId: number;
-  name: string;
-  fullName: string;
-  owner: string;
-  language: string | null;
-  description: string | null;
-  htmlUrl: string;
-  homepage: string | null;
-  topics: string | null; // JSON文字列
-  createdAt: string;
-  updatedAt: string;
-  pushedAt: string | null;
-}
+export type {
+  Repository,
+  RepoSnapshot,
+  MetricsDaily,
+  Language,
+} from './types/repository';
 
-// Snapshot型
-export interface RepoSnapshot {
-  id: number;
-  repoId: number;
-  stars: number;
-  forks: number;
-  watchers: number;
-  openIssues: number;
-  snapshotDate: string; // ISO date: "2026-01-12"
-  createdAt: string;
-}
-
-// APIレスポンス型
-export interface TrendItem {
-  repoId: number;
-  name: string;
-  fullName: string;
-  owner: string;
-  language: string | null;
-  description: string | null;
-  htmlUrl: string;
-  currentStars: number | null; // LEFT JOINでスナップショットがない場合はnull
-  snapshotDate?: string | null;
-  weeklyGrowth: number | null; // 過去7日間のスター増加数
-  weeklyGrowthRate: number | null; // 増加率（%）
-}
-
-// 検索・フィルタ・ソートのパラメータ型
-export type TrendSortField = 'stars' | 'growth_rate' | 'weekly_growth';
-export type SortOrder = 'asc' | 'desc';
-
-export interface TrendsQueryParams {
-  /** 言語フィルタ */
-  language?: string;
-  /** テキスト検索（リポジトリ名、説明文、オーナー名） */
-  q?: string;
-  /** 最小スター数 */
-  minStars?: number;
-  /** 最大スター数 */
-  maxStars?: number;
-  /** ソートフィールド */
-  sort?: TrendSortField;
-  /** ソート順序 */
-  order?: SortOrder;
-  /** 取得件数 */
-  limit?: number;
-}
-
-export interface TrendsResponse {
-  language?: string;
-  trends: TrendItem[];
-  /** 適用されたフィルタ情報 */
-  filters?: {
-    q?: string;
-    minStars?: number;
-    maxStars?: number;
-    sort?: TrendSortField;
-    order?: SortOrder;
-  };
-}
-
-export interface HistoryResponse {
-  history: RepoSnapshot[];
-}
-
-// リポジトリ詳細レスポンス型
-export interface RepoDetailResponse {
-  repository: {
-    repoId: number;
-    name: string;
-    fullName: string;
-    owner: string;
-    language: string | null;
-    description: string | null;
-    htmlUrl: string;
-    homepage: string | null;
-    topics: string[];
-  };
-  currentStats: {
-    stars: number;
-    forks: number;
-    watchers: number;
-    openIssues: number;
-    snapshotDate: string;
-  } | null;
-  weeklyGrowth: number | null;
-  weeklyGrowthRate: number | null;
-}
-
-// /api/trends/daily レスポンス型
-export interface TrendsDailyItem {
-  id: string;
-  full_name: string;
-  description: string | null;
-  language: string | null;
-  stargazers_count: number;
-  forks_count: number;
-  stars_7d_increase: number;
-  stars_30d_increase: number;
-  stars_7d_rate: number;
-  stars_30d_rate: number;
-}
-
-export interface TrendsDailyPagination {
-  page: number;
-  limit: number;
-  total: number;
-  totalPages: number;
-}
-
-export interface TrendsDailyResponse {
-  data: TrendsDailyItem[];
-  pagination: TrendsDailyPagination;
-  metadata: {
-    snapshot_date: string;
-  };
-}
-
-export interface LanguagesResponse {
-  languages: (string | null)[];
-}
-
-export interface HealthResponse {
-  status: 'ok' | 'unhealthy';
-  timestamp: string;
-  database: 'connected' | 'disconnected';
-}
-
-export interface ErrorResponse {
-  error: string;
-}
-
-/**
- * API エラーレスポンス型（OpenAPI準拠）
- *
- * エラーコード一覧:
- * - VALIDATION_ERROR: 入力バリデーションエラー
- * - NOT_FOUND: リソースが見つからない
- * - DB_ERROR: データベースエラー
- * - INTERNAL_ERROR: 内部サーバーエラー
- */
-export type ErrorCode = 'VALIDATION_ERROR' | 'NOT_FOUND' | 'DB_ERROR' | 'INTERNAL_ERROR';
-
-export interface ApiError {
-  /** エラーメッセージ */
-  error: string;
-  /** エラーコード（オプション） */
-  code?: ErrorCode;
-  /** トレース用ID（デバッグ用、オプション） */
-  traceId?: string;
-}
+export type {
+  TrendItem,
+  TrendSortField,
+  SortOrder,
+  SortBy,
+  TrendsQueryParams,
+  TrendsResponse,
+  HistoryResponse,
+  RepoDetailResponse,
+  TrendsDailyItem,
+  TrendsDailyPagination,
+  PaginationMeta,
+  TrendsDailyResponse,
+  LanguagesResponse,
+  HealthResponse,
+  ErrorResponse,
+  ErrorCode,
+  ApiError,
+} from './types/api';

--- a/shared/src/types/api.ts
+++ b/shared/src/types/api.ts
@@ -1,0 +1,151 @@
+/**
+ * API レスポンス・リクエスト関連の型定義
+ */
+
+import type { RepoSnapshot } from './repository';
+
+// トレンドアイテム型
+export interface TrendItem {
+  repoId: number;
+  name: string;
+  fullName: string;
+  owner: string;
+  language: string | null;
+  description: string | null;
+  htmlUrl: string;
+  currentStars: number | null; // LEFT JOINでスナップショットがない場合はnull
+  snapshotDate?: string | null;
+  weeklyGrowth: number | null; // 過去7日間のスター増加数
+  weeklyGrowthRate: number | null; // 増加率（%）
+}
+
+// 検索・フィルタ・ソートのパラメータ型
+export type TrendSortField = 'stars' | 'growth_rate' | 'weekly_growth';
+export type SortOrder = 'asc' | 'desc';
+
+// trends/daily用ソートオプション
+export type SortBy = '7d_increase' | '30d_increase' | '7d_rate' | '30d_rate' | 'total_stars';
+
+export interface TrendsQueryParams {
+  /** 言語フィルタ */
+  language?: string;
+  /** テキスト検索（リポジトリ名、説明文、オーナー名） */
+  q?: string;
+  /** 最小スター数 */
+  minStars?: number;
+  /** 最大スター数 */
+  maxStars?: number;
+  /** ソートフィールド */
+  sort?: TrendSortField;
+  /** ソート順序 */
+  order?: SortOrder;
+  /** 取得件数 */
+  limit?: number;
+}
+
+export interface TrendsResponse {
+  language?: string;
+  trends: TrendItem[];
+  /** 適用されたフィルタ情報 */
+  filters?: {
+    q?: string;
+    minStars?: number;
+    maxStars?: number;
+    sort?: TrendSortField;
+    order?: SortOrder;
+  };
+}
+
+export interface HistoryResponse {
+  history: RepoSnapshot[];
+}
+
+// リポジトリ詳細レスポンス型
+export interface RepoDetailResponse {
+  repository: {
+    repoId: number;
+    name: string;
+    fullName: string;
+    owner: string;
+    language: string | null;
+    description: string | null;
+    htmlUrl: string;
+    homepage: string | null;
+    topics: string[];
+  };
+  currentStats: {
+    stars: number;
+    forks: number;
+    watchers: number;
+    openIssues: number;
+    snapshotDate: string;
+  } | null;
+  weeklyGrowth: number | null;
+  weeklyGrowthRate: number | null;
+}
+
+// /api/trends/daily レスポンス型
+export interface TrendsDailyItem {
+  id: string;
+  full_name: string;
+  description: string | null;
+  language: string | null;
+  stargazers_count: number;
+  forks_count: number;
+  stars_7d_increase: number;
+  stars_30d_increase: number;
+  stars_7d_rate: number;
+  stars_30d_rate: number;
+}
+
+export interface TrendsDailyPagination {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+/** TrendsDailyPaginationの汎用エイリアス */
+export type PaginationMeta = TrendsDailyPagination;
+
+export interface TrendsDailyResponse {
+  data: TrendsDailyItem[];
+  pagination: TrendsDailyPagination;
+  metadata: {
+    snapshot_date: string;
+  };
+}
+
+export interface LanguagesResponse {
+  languages: (string | null)[];
+}
+
+export interface HealthResponse {
+  status: 'ok' | 'unhealthy';
+  timestamp: string;
+  database: 'connected' | 'disconnected';
+}
+
+export interface ErrorResponse {
+  error: string;
+}
+
+/**
+ * API エラーレスポンス型（OpenAPI準拠）
+ *
+ * エラーコード一覧:
+ * - VALIDATION_ERROR: 入力バリデーションエラー
+ * - NOT_FOUND: リソースが見つからない
+ * - DB_ERROR: データベースエラー
+ * - INTERNAL_ERROR: 内部サーバーエラー
+ */
+export type ErrorCode = 'VALIDATION_ERROR' | 'NOT_FOUND' | 'DB_ERROR' | 'INTERNAL_ERROR';
+
+export interface ApiError {
+  /** エラーメッセージ */
+  error: string;
+  /** エラーコード（オプション） */
+  code?: ErrorCode;
+  /** トレース用ID（デバッグ用、オプション） */
+  traceId?: string;
+}

--- a/shared/src/types/repository.ts
+++ b/shared/src/types/repository.ts
@@ -1,0 +1,58 @@
+/**
+ * リポジトリ関連の型定義
+ */
+
+// Repository型（データベーススキーマから派生）
+export interface Repository {
+  repoId: number;
+  name: string;
+  fullName: string;
+  owner: string;
+  language: string | null;
+  description: string | null;
+  htmlUrl: string;
+  homepage: string | null;
+  topics: string | null; // JSON文字列
+  createdAt: string;
+  updatedAt: string;
+  pushedAt: string | null;
+}
+
+// Snapshot型
+export interface RepoSnapshot {
+  id: number;
+  repoId: number;
+  stars: number;
+  forks: number;
+  watchers: number;
+  openIssues: number;
+  snapshotDate: string; // ISO date: "2026-01-12"
+  createdAt: string;
+}
+
+/**
+ * 日次メトリクス型（API wire format: snake_case）
+ *
+ * Note: apps/backend/src/db/schema.ts にも同名の Drizzle ORM 推論型が存在するが、
+ * そちらは camelCase（例: stars7dIncrease）。この型は API レスポンス用。
+ */
+export interface MetricsDaily {
+  repo_id: number;
+  calculated_date: string;
+  stars_7d_increase: number;
+  stars_30d_increase: number;
+  stars_7d_rate: number;
+  stars_30d_rate: number;
+}
+
+/**
+ * 言語型（API wire format: snake_case）
+ *
+ * Note: apps/backend/src/db/schema.ts にも同名の Drizzle ORM 推論型が存在するが、
+ * そちらは camelCase（例: nameJa, sortOrder）。この型は API レスポンス用。
+ */
+export interface Language {
+  code: string;
+  name_ja: string;
+  sort_order: number;
+}


### PR DESCRIPTION
## Summary
- 共有型定義をファイル分割（`types/repository.ts`, `types/api.ts`）して整理
- Issue #62 で要求された不足型（`MetricsDaily`, `Language`, `SortBy`, `PaginationMeta`）を追加
- `index.ts` からの re-export により既存の全インポートの後方互換性を維持

## Changes

### 新規ファイル
- **`shared/src/types/repository.ts`** — エンティティ型: `Repository`, `RepoSnapshot`, `MetricsDaily`, `Language`
- **`shared/src/types/api.ts`** — API型: 全レスポンス/リクエスト型, `SortBy`, `PaginationMeta`

### 変更ファイル
- **`shared/src/index.ts`** — インライン定義を新ファイルからの re-export に置換

### 追加された新型
| 型 | 説明 |
|---|---|
| `MetricsDaily` | 日次メトリクスエンティティ（API wire format, snake_case） |
| `Language` | 言語エンティティ（`code`, `name_ja`, `sort_order`） |
| `SortBy` | trends/daily エンドポイント用ソートオプション |
| `PaginationMeta` | `TrendsDailyPagination` の汎用エイリアス |

### 設計判断
- `MetricsDaily`, `Language` は API wire format（snake_case）で定義。`db/schema.ts` の同名 Drizzle ORM 推論型（camelCase）との違いを JSDoc で明記
- 既存型（`Repository`, `RepoSnapshot` 等）は camelCase のまま維持（17箇所以上のインポートが依存）

## Test plan
- [x] `npm run type-check` — 0 errors, 0 warnings
- [x] `npm run ci:lint` — clean
- [x] `npm run test:backend` — 18/18 tests passed
- [x] `npm run build` — completed

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)