### PR TITLE
feat(frontend): メトリクス表示の実装（7日/30日増加数バッジ）

### DIFF
--- a/apps/frontend/src/components/MetricsBadge.tsx
+++ b/apps/frontend/src/components/MetricsBadge.tsx
@@ -1,0 +1,44 @@
+/**
+ * MetricsBadge コンポーネント (COM-006)
+ * スター増加数/増加率を色付きバッジとして表示する。
+ * 使用箇所: TrendList, RepositoryListItem
+ */
+
+interface MetricsBadgeProps {
+  value: number;
+  period: '7d' | '30d';
+  type?: 'increase' | 'rate';
+}
+
+function getVariant(value: number): 'positive' | 'negative' | 'zero' {
+  if (value > 0) return 'positive';
+  if (value < 0) return 'negative';
+  return 'zero';
+}
+
+function getArrow(value: number): string {
+  if (value > 0) return '↑';
+  if (value < 0) return '↓';
+  return '→';
+}
+
+function formatValue(value: number, type: 'increase' | 'rate'): string {
+  if (type === 'rate') {
+    const sign = value > 0 ? '+' : '';
+    return `${sign}${value.toFixed(2)}%`;
+  }
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value.toLocaleString()}`;
+}
+
+export default function MetricsBadge({ value, period, type = 'increase' }: MetricsBadgeProps) {
+  const variant = getVariant(value);
+
+  return (
+    <span className={`metrics-badge metrics-badge--${variant}`}>
+      <span className="metrics-badge__arrow">{getArrow(value)}</span>
+      <span className="metrics-badge__value">{formatValue(value, type)}</span>
+      <span className="metrics-badge__period">/{period}</span>
+    </span>
+  );
+}

--- a/apps/frontend/src/components/RepositoryListItem.tsx
+++ b/apps/frontend/src/components/RepositoryListItem.tsx
@@ -1,8 +1,10 @@
 /**
- * RepositoryListItem Component (COM-001)
- * Displays a single repository as a card/row in list views.
- * Used in: scr-001, scr-003, scr-004, scr-010
+ * RepositoryListItem コンポーネント (COM-001)
+ * リポジトリ1件をカード/行として表示する。
+ * 使用箇所: scr-001, scr-003, scr-004, scr-010
  */
+
+import MetricsBadge from './MetricsBadge';
 
 interface RepositoryListItemProps {
   repo: {
@@ -26,11 +28,6 @@ function formatNumber(num: number): string {
     return `${(num / 1000).toFixed(1)}k`;
   }
   return num.toLocaleString();
-}
-
-function formatGrowth(value: number): string {
-  const sign = value >= 0 ? '+' : '';
-  return `${sign}${value.toLocaleString()}`;
 }
 
 export default function RepositoryListItem({
@@ -69,20 +66,10 @@ export default function RepositoryListItem({
         </span>
 
         {showMetrics && metrics && (
-          <>
-            <span
-              className={`repo-list-item__metric ${metrics.stars_7d_increase > 0 ? 'repo-list-item__metric--positive' : ''}`}
-              title="7-day star increase"
-            >
-              7d: {formatGrowth(metrics.stars_7d_increase)}
-            </span>
-            <span
-              className={`repo-list-item__metric ${metrics.stars_30d_increase > 0 ? 'repo-list-item__metric--positive' : ''}`}
-              title="30-day star increase"
-            >
-              30d: {formatGrowth(metrics.stars_30d_increase)}
-            </span>
-          </>
+          <div className="metrics-badge-group">
+            <MetricsBadge value={metrics.stars_7d_increase} period="7d" />
+            <MetricsBadge value={metrics.stars_30d_increase} period="30d" />
+          </div>
         )}
       </div>
     </div>

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -777,6 +777,55 @@ input:focus {
   }
 }
 
+/* ========================================
+   MetricsBadge (COM-006)
+   ======================================== */
+.metrics-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: 12px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.metrics-badge--positive {
+  background: #dcffe4;
+  color: #22863a;
+}
+
+.metrics-badge--negative {
+  background: #ffeef0;
+  color: #c53030;
+}
+
+.metrics-badge--zero {
+  background: #f1f1f1;
+  color: #586069;
+}
+
+.metrics-badge__arrow {
+  font-size: 0.75rem;
+}
+
+.metrics-badge__value {
+  font-weight: 600;
+}
+
+.metrics-badge__period {
+  font-size: 0.6875rem;
+  opacity: 0.7;
+}
+
+.metrics-badge-group {
+  display: flex;
+  gap: 0.375rem;
+  align-items: center;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   body {
@@ -850,6 +899,12 @@ input:focus {
   .repo-list-item__stats {
     flex-wrap: wrap;
     gap: 0.5rem;
+  }
+
+  /* MetricsBadge Mobile */
+  .metrics-badge-group {
+    flex-direction: column;
+    gap: 0.25rem;
   }
 
   /* Pagination Mobile */


### PR DESCRIPTION
## Summary
- MetricsBadge コンポーネントを新規作成（7d/30d の増加数をバッジ形式で表示）
- TrendList の Growth 列を MetricsBadge に置き換え（2列→1列に統合）
- RepositoryListItem の手動メトリクス表示を MetricsBadge に置き換え
- 増加率ソート時（7d_rate, 30d_rate）はパーセンテージ表示に自動切替

## Test plan
- [x] ESLint: 0 errors, 0 warnings
- [x] TypeScript: 0 errors
- [x] Backend tests: 18/18 passed
- [x] Build: successful
- [ ] 7日間増加数がバッジで表示される
- [ ] 30日間増加数がバッジで表示される
- [ ] 増加率ソート時は%表示に切り替わる
- [ ] 正/負/ゼロで色分けされる（緑/赤/グレー）
- [ ] レスポンシブ対応（モバイルでは縦並び）

## Changes
- **New**: `apps/frontend/src/components/MetricsBadge.tsx` - Reusable badge component (COM-006)
- **Updated**: `apps/frontend/src/components/TrendList.tsx` - Integrated MetricsBadge, merged 7d/30d Growth into single column
- **Updated**: `apps/frontend/src/components/RepositoryListItem.tsx` - Replaced manual metric rendering with MetricsBadge
- **Updated**: `apps/frontend/src/styles/global.css` - Added MetricsBadge BEM styles with responsive rules

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)