### PR TITLE
feat(frontend): お気に入りローカルストレージ保存機能 (#78)

### DIFF
--- a/apps/frontend/src/components/FavoriteButton.tsx
+++ b/apps/frontend/src/components/FavoriteButton.tsx
@@ -1,0 +1,39 @@
+/**
+ * FavoriteButton Component
+ * お気に入り登録/解除ボタン
+ */
+
+import React from 'react';
+
+export interface FavoriteButtonProps {
+  repo: { id: string; full_name: string };
+  isFavorite: boolean;
+  onToggle: (repo: { id: string; full_name: string }) => void;
+  size?: 'small' | 'medium' | 'large';
+}
+
+export default function FavoriteButton({
+  repo,
+  isFavorite,
+  onToggle,
+  size = 'medium',
+}: FavoriteButtonProps) {
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault(); // リンククリックを防ぐ
+    onToggle(repo);
+  };
+
+  const sizeClass = `favorite-button--${size}`;
+  const activeClass = isFavorite ? 'favorite-button--active' : '';
+
+  return (
+    <button
+      className={`favorite-button ${sizeClass} ${activeClass}`}
+      onClick={handleClick}
+      aria-label={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+      title={isFavorite ? 'お気に入りから削除' : 'お気に入りに追加'}
+    >
+      {isFavorite ? '★' : '☆'}
+    </button>
+  );
+}

--- a/apps/frontend/src/components/RepoDetail.tsx
+++ b/apps/frontend/src/components/RepoDetail.tsx
@@ -3,9 +3,10 @@
  * Displays detailed repository information with stats and star history chart
  */
 
-import React from 'react';
 import type { RepoDetailResponse } from '@gh-trend-tracker/shared';
 import StarChart from './StarChart';
+import FavoriteButton from './FavoriteButton';
+import { useFavorites } from '../hooks/useFavorites';
 
 interface ChartData {
   date: string;
@@ -38,15 +39,24 @@ function getGrowthClass(rate: number | null): string {
 
 export default function RepoDetail({ detail, history }: Props) {
   const { repository, currentStats, weeklyGrowth, weeklyGrowthRate } = detail;
+  const { isFavorite, toggleFavorite } = useFavorites();
 
   return (
     <div className="repo-detail">
       <header className="repo-header">
-        <h1>
-          <a href={repository.htmlUrl} target="_blank" rel="noopener noreferrer">
-            {repository.fullName}
-          </a>
-        </h1>
+        <div className="repo-title-row">
+          <h1>
+            <a href={repository.htmlUrl} target="_blank" rel="noopener noreferrer">
+              {repository.fullName}
+            </a>
+          </h1>
+          <FavoriteButton
+            repo={{ id: String(repository.repoId), full_name: repository.fullName }}
+            isFavorite={isFavorite(String(repository.repoId))}
+            onToggle={toggleFavorite}
+            size="large"
+          />
+        </div>
         {repository.description && <p className="repo-description">{repository.description}</p>}
         <div className="repo-meta">
           {repository.language && <span className="language-badge">{repository.language}</span>}

--- a/apps/frontend/src/hooks/useFavorites.ts
+++ b/apps/frontend/src/hooks/useFavorites.ts
@@ -1,0 +1,102 @@
+/**
+ * useFavorites Hook
+ * ローカルストレージを使ったお気に入り管理フック
+ */
+
+import { useState, useEffect } from 'react';
+
+const STORAGE_KEY = 'gh-trend-tracker:favorites';
+
+export interface FavoriteItem {
+  repoId: string;
+  fullName: string;
+  addedAt: string; // ISO 8601
+}
+
+export interface UseFavoritesReturn {
+  favorites: FavoriteItem[];
+  isFavorite: (repoId: string) => boolean;
+  addFavorite: (repo: { id: string; full_name: string }) => void;
+  removeFavorite: (repoId: string) => void;
+  toggleFavorite: (repo: { id: string; full_name: string }) => void;
+}
+
+/**
+ * ローカルストレージからお気に入りリストを取得
+ */
+function loadFavorites(): FavoriteItem[] {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return [];
+    return JSON.parse(stored) as FavoriteItem[];
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to load favorites from localStorage:', error);
+    return [];
+  }
+}
+
+/**
+ * ローカルストレージにお気に入りリストを保存
+ */
+function saveFavorites(favorites: FavoriteItem[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(favorites));
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to save favorites to localStorage:', error);
+  }
+}
+
+export function useFavorites(): UseFavoritesReturn {
+  const [favorites, setFavorites] = useState<FavoriteItem[]>([]);
+
+  // 初期化: ローカルストレージから読み込み
+  useEffect(() => {
+    setFavorites(loadFavorites());
+  }, []);
+
+  // お気に入りかどうかをチェック
+  const isFavorite = (repoId: string): boolean => {
+    return favorites.some((fav) => fav.repoId === repoId);
+  };
+
+  // お気に入りに追加
+  const addFavorite = (repo: { id: string; full_name: string }): void => {
+    if (isFavorite(repo.id)) return;
+
+    const newFavorite: FavoriteItem = {
+      repoId: repo.id,
+      fullName: repo.full_name,
+      addedAt: new Date().toISOString(),
+    };
+
+    const updated = [...favorites, newFavorite];
+    setFavorites(updated);
+    saveFavorites(updated);
+  };
+
+  // お気に入りから削除
+  const removeFavorite = (repoId: string): void => {
+    const updated = favorites.filter((fav) => fav.repoId !== repoId);
+    setFavorites(updated);
+    saveFavorites(updated);
+  };
+
+  // お気に入りをトグル
+  const toggleFavorite = (repo: { id: string; full_name: string }): void => {
+    if (isFavorite(repo.id)) {
+      removeFavorite(repo.id);
+    } else {
+      addFavorite(repo);
+    }
+  };
+
+  return {
+    favorites,
+    isFavorite,
+    addFavorite,
+    removeFavorite,
+    toggleFavorite,
+  };
+}

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -269,8 +269,16 @@ input:focus {
   border-bottom: 1px solid #e1e4e8;
 }
 
-.repo-header h1 {
+.repo-title-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
   margin-bottom: 0.5rem;
+}
+
+.repo-header h1 {
+  margin-bottom: 0;
+  flex: 1;
 }
 
 .repo-header h1 a {
@@ -859,6 +867,46 @@ input:focus {
   display: flex;
   gap: 0.375rem;
   align-items: center;
+}
+
+/* ========================================
+   FavoriteButton
+   ======================================== */
+.favorite-button {
+  padding: 0.5rem;
+  font-size: 1.5rem;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  color: #d1d5da;
+  line-height: 1;
+  transition: all 0.15s ease;
+}
+
+.favorite-button:hover {
+  color: #e3b341;
+  border-color: #e1e4e8;
+  background: #f6f8fa;
+}
+
+.favorite-button--active {
+  color: #e3b341;
+}
+
+.favorite-button--small {
+  padding: 0.25rem;
+  font-size: 1rem;
+}
+
+.favorite-button--medium {
+  padding: 0.375rem 0.5rem;
+  font-size: 1.25rem;
+}
+
+.favorite-button--large {
+  padding: 0.5rem 0.75rem;
+  font-size: 1.5rem;
 }
 
 /* ========================================


### PR DESCRIPTION
## Summary
リポジトリのお気に入り状態をローカルストレージに保存する機能を実装しました。

## Changes
- `useFavorites` フック実装（ローカルストレージ操作）
- `FavoriteButton` コンポーネント実装（☆/★ トグルボタン）
- `RepoDetail` コンポーネントにお気に入りボタンを配置
- お気に入り登録/解除/トグル機能
- ローカルストレージへの永続化（キー: `gh-trend-tracker:favorites`）

## Test plan
- [x] お気に入り登録/解除が動作
- [x] ページリロードでも状態が保持される
- [x] 複数リポジトリを登録可能
- [x] 視覚的なフィードバックがある（☆→★）
- [x] 型チェック通過
- [x] Lint通過
- [x] ビルド成功

## Related
Closes #78

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>