### PR TITLE
feat(backend): 週別トレンドAPI エンドポイント実装 (bac-004, bac-005)

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -3,6 +3,8 @@ import { cors } from 'hono/cors';
 import { drizzle } from 'drizzle-orm/d1';
 import health from './routes/health';
 import trendsDaily from './routes/trends-daily';
+import trendsWeekly from './routes/trends-weekly';
+import trendsWeeklyAvailable from './routes/trends-weekly-available';
 import trends from './routes/trends';
 import repositories from './routes/repositories';
 import repositoriesSearch from './routes/repositories-search';
@@ -34,6 +36,8 @@ app.use('/*', dbMiddleware);
 // ルート登録
 app.route('/health', health);
 app.route('/api/trends/daily', trendsDaily);
+app.route('/api/trends/weekly/available-weeks', trendsWeeklyAvailable);
+app.route('/api/trends/weekly', trendsWeekly);
 app.route('/api/trends', trends);
 app.route('/api/repositories/search', repositoriesSearch);
 app.route('/api/repositories', repositories);

--- a/apps/backend/src/routes/trends-weekly-available.ts
+++ b/apps/backend/src/routes/trends-weekly-available.ts
@@ -1,0 +1,42 @@
+import { Hono } from 'hono';
+import { sql } from 'drizzle-orm';
+import { rankingWeekly } from '../db/schema';
+import { dbError } from '../shared/errors';
+import type { AvailableWeeksResponse, ApiError, AvailableWeek } from '@gh-trend-tracker/shared';
+import type { AppEnv } from '../types/app';
+
+const trendsWeeklyAvailable = new Hono<AppEnv>();
+
+trendsWeeklyAvailable.get('/', async (c) => {
+  const db = c.get('db');
+
+  try {
+    // ranking_weekly テーブルから集計済みの (year, week_number) のユニークなリストを取得
+    // 最新の週から降順で返す
+    const results = await db
+      .select({
+        year: rankingWeekly.year,
+        weekNumber: rankingWeekly.weekNumber,
+      })
+      .from(rankingWeekly)
+      .groupBy(rankingWeekly.year, rankingWeekly.weekNumber)
+      .orderBy(sql`${rankingWeekly.year} DESC, ${rankingWeekly.weekNumber} DESC`);
+
+    const weeks: AvailableWeek[] = results.map((row) => ({
+      year: row.year,
+      week: row.weekNumber,
+    }));
+
+    const response: AvailableWeeksResponse = {
+      weeks,
+    };
+
+    return c.json(response);
+  } catch (error) {
+    console.error('Error fetching available weeks:', error);
+    const errorResponse: ApiError = dbError('Failed to fetch available weeks');
+    return c.json(errorResponse, 500);
+  }
+});
+
+export default trendsWeeklyAvailable;

--- a/apps/backend/src/routes/trends-weekly.ts
+++ b/apps/backend/src/routes/trends-weekly.ts
@@ -1,0 +1,90 @@
+import { Hono } from 'hono';
+import { eq, and } from 'drizzle-orm';
+import { rankingWeekly } from '../db/schema';
+import { WeeklyTrendsQuerySchema } from '../schemas/weekly';
+import { validationError, notFoundError, dbError } from '../shared/errors';
+import type { WeeklyTrendResponse, ApiError, WeeklyTrendItem } from '@gh-trend-tracker/shared';
+import type { AppEnv } from '../types/app';
+
+const trendsWeekly = new Hono<AppEnv>();
+
+trendsWeekly.get('/', async (c) => {
+  const db = c.get('db');
+
+  // クエリパラメータをパース・バリデーション
+  const parsed = WeeklyTrendsQuerySchema.safeParse({
+    year: c.req.query('year'),
+    week: c.req.query('week'),
+    language: c.req.query('language'),
+  });
+
+  if (!parsed.success) {
+    const errorResponse: ApiError = validationError(
+      parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ')
+    );
+    return c.json(errorResponse, 400);
+  }
+
+  const { year, week, language } = parsed.data;
+
+  try {
+    // WHERE条件を構築
+    const conditions = [
+      eq(rankingWeekly.year, year),
+      eq(rankingWeekly.weekNumber, week),
+      eq(rankingWeekly.language, language ?? 'all'),
+    ];
+
+    // ranking_weekly テーブルから該当週のデータを取得
+    const [result] = await db
+      .select({
+        year: rankingWeekly.year,
+        weekNumber: rankingWeekly.weekNumber,
+        language: rankingWeekly.language,
+        rankData: rankingWeekly.rankData,
+      })
+      .from(rankingWeekly)
+      .where(and(...conditions))
+      .limit(1);
+
+    if (!result) {
+      const errorResponse: ApiError = notFoundError(
+        `No ranking data found for year=${year}, week=${week}, language=${language ?? 'all'}`
+      );
+      return c.json(errorResponse, 404);
+    }
+
+    // rank_data は JSON 文字列として保存されているのでパース
+    const rankData = JSON.parse(result.rankData) as Array<{
+      rank: number;
+      repo_id: number;
+      repo_full_name: string;
+      star_increase: number;
+    }>;
+
+    // レスポンス形式に変換
+    const ranking: WeeklyTrendItem[] = rankData.map((item) => ({
+      rank: item.rank,
+      repo_id: String(item.repo_id),
+      repo_full_name: item.repo_full_name,
+      star_increase: item.star_increase,
+    }));
+
+    const response: WeeklyTrendResponse = {
+      metadata: {
+        year: result.year,
+        week: result.weekNumber,
+        language: result.language,
+      },
+      ranking,
+    };
+
+    return c.json(response);
+  } catch (error) {
+    console.error('Error fetching weekly trends:', error);
+    const errorResponse: ApiError = dbError('Failed to fetch weekly trends');
+    return c.json(errorResponse, 500);
+  }
+});
+
+export default trendsWeekly;

--- a/apps/backend/src/schemas/weekly.ts
+++ b/apps/backend/src/schemas/weekly.ts
@@ -1,0 +1,15 @@
+/**
+ * 週別トレンドAPI関連のZodスキーマ定義（ランタイムバリデーション用）
+ */
+import { z } from 'zod';
+
+/**
+ * /api/trends/weekly クエリパラメータスキーマ
+ */
+export const WeeklyTrendsQuerySchema = z.object({
+  year: z.coerce.number().int().min(2020).max(2100),
+  week: z.coerce.number().int().min(1).max(53),
+  language: z.string().optional(),
+});
+
+export type WeeklyTrendsQuery = z.infer<typeof WeeklyTrendsQuerySchema>;

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -28,4 +28,8 @@ export type {
   BatchWeeklyRankingResponse,
   SearchResultItem,
   SearchResponse,
+  WeeklyTrendItem,
+  WeeklyTrendResponse,
+  AvailableWeek,
+  AvailableWeeksResponse,
 } from './types/api';

--- a/shared/src/types/api.ts
+++ b/shared/src/types/api.ts
@@ -223,3 +223,32 @@ export interface SearchResponse {
   data: SearchResultItem[];
   total: number;
 }
+
+/** 週別トレンドランキングアイテム型（bac-004用） */
+export interface WeeklyTrendItem {
+  rank: number;
+  repo_id: string;
+  repo_full_name: string;
+  star_increase: number;
+}
+
+/** 週別トレンドランキングレスポンス型（bac-004） */
+export interface WeeklyTrendResponse {
+  metadata: {
+    year: number;
+    week: number;
+    language: string;
+  };
+  ranking: WeeklyTrendItem[];
+}
+
+/** 利用可能週の情報型 */
+export interface AvailableWeek {
+  year: number;
+  week: number;
+}
+
+/** 利用可能週リストレスポンス型（bac-005） */
+export interface AvailableWeeksResponse {
+  weeks: AvailableWeek[];
+}


### PR DESCRIPTION
## Summary

週別トレンドランキング取得と利用可能週リスト取得のAPIエンドポイントを実装しました。

## 実装内容

### エンドポイント
- `GET /api/trends/weekly`: 週別トレンドランキング取得 (bac-004)
  - クエリパラメータ: `year`, `week`, `language` (optional)
  - レスポンス: 指定年週のランキングデータ
- `GET /api/trends/weekly/available-weeks`: 利用可能週リスト取得 (bac-005)
  - レスポンス: 集計済みの年週のリスト（降順）

### 実装ファイル
- `apps/backend/src/routes/trends-weekly.ts`: 週別ランキング取得
- `apps/backend/src/routes/trends-weekly-available.ts`: 利用可能週リスト取得
- `apps/backend/src/schemas/weekly.ts`: Zodバリデーションスキーマ
- `shared/src/types/api.ts`: API型定義の追加

## Test plan

### 動作確認済み
- [x] 週別ランキングが取得できる (year=2026, week=6)
- [x] 言語フィルタリングが動作 (language=typescript)
- [x] 利用可能週リストが取得できる
- [x] バリデーションエラー時に適切なレスポンス (week=99 → VALIDATION_ERROR)
- [x] 必須パラメータ欠如時のエラー (week未指定 → VALIDATION_ERROR)
- [x] データなし時のエラー (week=1 → NOT_FOUND)

### テストコマンド
```bash
# ローカルD1テーブル作成
npx wrangler d1 execute gh-trends-db --local --file=schema/schema.sql

# サンプルデータ挿入
npx wrangler d1 execute gh-trends-db --local --command="INSERT INTO ranking_weekly ..."

# 開発サーバー起動
npm run dev:backend

# エンドポイントテスト
curl "http://localhost:8787/api/trends/weekly/available-weeks"
curl "http://localhost:8787/api/trends/weekly?year=2026&week=6"
curl "http://localhost:8787/api/trends/weekly?year=2026&week=6&language=typescript"
```

## Changes
- 週別トレンド関連の型定義・スキーマ追加
- 週別ランキング取得エンドポイント実装
- 利用可能週リスト取得エンドポイント実装
- ルート登録（available-weeks を weekly より前に配置）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #81