### PR TITLE
feat: Stripe連携・課金UI実装 (#92)

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -15,6 +15,8 @@ import loginGithub from './routes/auth/login-github';
 import callbackGithub from './routes/auth/callback-github';
 import me from './routes/auth/me';
 import logout from './routes/auth/logout';
+import billingCheckout from './routes/billing/checkout';
+import stripeWebhook from './routes/webhook/stripe';
 import { dbMiddleware } from './middleware/database';
 import { rateLimitMiddleware } from './middleware/rate-limit';
 import { runDailyCollection } from './services/batch-collector';
@@ -43,6 +45,7 @@ app.use('/api/trends/*', rateLimitMiddleware(60 * 1000, 100));
 app.use('/api/repositories/*', rateLimitMiddleware(60 * 1000, 100));
 app.use('/api/languages', rateLimitMiddleware(60 * 1000, 100));
 app.use('/api/auth/*', rateLimitMiddleware(60 * 1000, 100));
+app.use('/api/billing/*', rateLimitMiddleware(60 * 1000, 100));
 
 // データベースミドルウェア
 app.use('/*', dbMiddleware);
@@ -59,6 +62,8 @@ app.route('/api/auth/login/github', loginGithub);
 app.route('/api/auth/callback/github', callbackGithub);
 app.route('/api/auth/me', me);
 app.route('/api/auth/logout', logout);
+app.route('/api/billing/checkout', billingCheckout);
+app.route('/api/webhook/stripe', stripeWebhook);
 app.route('/api/internal/batch/collect-daily', collectDaily);
 app.route('/api/internal/batch/calculate-metrics', calculateMetrics);
 app.route('/api/internal/batch/calculate-weekly', calculateWeekly);

--- a/apps/backend/src/routes/billing/checkout.test.ts
+++ b/apps/backend/src/routes/billing/checkout.test.ts
@@ -1,0 +1,117 @@
+/**
+ * POST /api/billing/checkout のテスト
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { env, SELF } from 'cloudflare:test';
+import { generateJwt } from '../../services/jwt';
+
+describe('POST /api/billing/checkout', () => {
+  beforeAll(async () => {
+    await env.DB.prepare(`
+      CREATE TABLE IF NOT EXISTS users (
+        id TEXT PRIMARY KEY,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        github_id INTEGER NOT NULL UNIQUE,
+        username TEXT NOT NULL,
+        email TEXT,
+        avatar_url TEXT,
+        plan TEXT NOT NULL DEFAULT 'FREE',
+        credits_remaining INTEGER NOT NULL DEFAULT 0,
+        stripe_customer_id TEXT,
+        subscription_expires_at TEXT
+      )
+    `).run();
+
+    await env.DB.prepare(
+      `INSERT OR IGNORE INTO users (
+        id, created_at, updated_at, github_id, username, plan, credits_remaining
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+    )
+      .bind(
+        'billing-test-user-id',
+        new Date().toISOString(),
+        new Date().toISOString(),
+        999001,
+        'billinguser',
+        'FREE',
+        0
+      )
+      .run();
+  });
+
+  it('認証なしの場合は401を返す', async () => {
+    const res = await SELF.fetch('http://example.com/api/billing/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ plan: 'PRO' }),
+    });
+
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data).toHaveProperty('error');
+  });
+
+  it('無効なプランの場合は400を返す', async () => {
+    const token = await generateJwt(
+      { userId: 'billing-test-user-id', username: 'billinguser' },
+      env.JWT_SECRET,
+      { expiresIn: 3600 }
+    );
+
+    const res = await SELF.fetch('http://example.com/api/billing/checkout', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `auth_token=${token}`,
+      },
+      body: JSON.stringify({ plan: 'INVALID' }),
+    });
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data).toHaveProperty('error');
+  });
+
+  it('Stripe未設定の場合は500を返す', async () => {
+    const token = await generateJwt(
+      { userId: 'billing-test-user-id', username: 'billinguser' },
+      env.JWT_SECRET,
+      { expiresIn: 3600 }
+    );
+
+    // STRIPE_SECRET_KEYが設定されていない場合
+    const res = await SELF.fetch('http://example.com/api/billing/checkout', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `auth_token=${token}`,
+      },
+      body: JSON.stringify({ plan: 'PRO' }),
+    });
+
+    // Stripe未設定なら500
+    expect(res.status).toBe(500);
+  });
+
+  it('リクエストボディなしの場合は4xxまたは5xxを返す', async () => {
+    const token = await generateJwt(
+      { userId: 'billing-test-user-id', username: 'billinguser' },
+      env.JWT_SECRET,
+      { expiresIn: 3600 }
+    );
+
+    const res = await SELF.fetch('http://example.com/api/billing/checkout', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `auth_token=${token}`,
+      },
+      body: 'not-json',
+    });
+
+    // Stripe未設定のため500、またはボディ解析エラーで400
+    expect(res.status >= 400).toBe(true);
+  });
+});

--- a/apps/backend/src/routes/billing/checkout.ts
+++ b/apps/backend/src/routes/billing/checkout.ts
@@ -1,0 +1,68 @@
+/**
+ * Stripe Checkoutセッション生成エンドポイント
+ * POST /api/billing/checkout
+ * Related: fun-049 (Stripe Checkoutセッション生成・リダイレクト), bac-009
+ */
+
+import { Hono } from 'hono';
+import { authMiddleware } from '../../middleware/auth';
+import { createCheckoutSession } from '../../services/stripe';
+import type { AppEnv } from '../../types/app';
+import type { AuthVariables } from '../../middleware/auth';
+import type { PlanType } from '../../services/stripe';
+
+const billingCheckout = new Hono<AppEnv & { Variables: AuthVariables }>();
+
+billingCheckout.post('/', authMiddleware, async (c) => {
+  const user = c.get('user');
+
+  let body: { plan?: string };
+  try {
+    body = await c.req.json<{ plan?: string }>();
+  } catch {
+    return c.json({ error: 'Invalid request body' }, 400);
+  }
+
+  const plan = body.plan as PlanType | undefined;
+  if (!plan || !['PRO', 'ENTERPRISE'].includes(plan)) {
+    return c.json({ error: 'Invalid plan. Must be PRO or ENTERPRISE' }, 400);
+  }
+
+  const stripeSecretKey = c.env.STRIPE_SECRET_KEY;
+  const stripePriceProId = c.env.STRIPE_PRICE_PRO;
+  const stripePriceEnterpriseId = c.env.STRIPE_PRICE_ENTERPRISE;
+  const frontendUrl = c.env.FRONTEND_URL ?? 'http://localhost:4321';
+
+  if (!stripeSecretKey) {
+    return c.json({ error: 'Stripe not configured' }, 500);
+  }
+
+  const stripePriceId = plan === 'PRO' ? stripePriceProId : stripePriceEnterpriseId;
+  if (!stripePriceId) {
+    return c.json({ error: `Stripe price ID for ${plan} plan not configured` }, 500);
+  }
+
+  try {
+    const session = await createCheckoutSession({
+      userId: user.userId,
+      plan,
+      stripeSecretKey,
+      stripePriceId,
+      successUrl: `${frontendUrl}/billing/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancelUrl: `${frontendUrl}/billing/cancel`,
+    });
+
+    return c.json({ url: session.url, sessionId: session.sessionId });
+  } catch (error) {
+    console.error('Stripe checkout error:', error);
+    return c.json(
+      {
+        error: 'Failed to create checkout session',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      500
+    );
+  }
+});
+
+export default billingCheckout;

--- a/apps/backend/src/routes/webhook/stripe.test.ts
+++ b/apps/backend/src/routes/webhook/stripe.test.ts
@@ -1,0 +1,98 @@
+/**
+ * POST /api/webhook/stripe のテスト
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { env, SELF } from 'cloudflare:test';
+import { verifyWebhookSignature } from '../../services/stripe';
+
+describe('POST /api/webhook/stripe', () => {
+  beforeAll(async () => {
+    await env.DB.prepare(`
+      CREATE TABLE IF NOT EXISTS users (
+        id TEXT PRIMARY KEY,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        github_id INTEGER NOT NULL UNIQUE,
+        username TEXT NOT NULL,
+        email TEXT,
+        avatar_url TEXT,
+        plan TEXT NOT NULL DEFAULT 'FREE',
+        credits_remaining INTEGER NOT NULL DEFAULT 0,
+        stripe_customer_id TEXT,
+        subscription_expires_at TEXT
+      )
+    `).run();
+
+    await env.DB.prepare(
+      `INSERT OR IGNORE INTO users (
+        id, created_at, updated_at, github_id, username, plan, credits_remaining
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+    )
+      .bind(
+        'webhook-test-user-id',
+        new Date().toISOString(),
+        new Date().toISOString(),
+        999002,
+        'webhookuser',
+        'FREE',
+        0
+      )
+      .run();
+  });
+
+  it('stripe-signatureヘッダーなしの場合は400を返す', async () => {
+    const res = await SELF.fetch('http://example.com/api/webhook/stripe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'checkout.session.completed' }),
+    });
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data).toHaveProperty('error');
+  });
+
+  it('Webhook秘密鍵未設定の場合は500を返す', async () => {
+    const res = await SELF.fetch('http://example.com/api/webhook/stripe', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'stripe-signature': 't=123,v1=abc',
+      },
+      body: JSON.stringify({ type: 'checkout.session.completed' }),
+    });
+
+    // STRIPE_WEBHOOK_SECRETが未設定の場合は500
+    expect(res.status).toBe(500);
+  });
+
+  it('無効な署名の場合は400を返す', async () => {
+    // 環境変数 STRIPE_WEBHOOK_SECRET がない場合、署名検証失敗前に500が返るため
+    // verifyWebhookSignatureの単体テストで検証
+    const isValid = await verifyWebhookSignature(
+      '{"type":"checkout.session.completed"}',
+      't=1234567890,v1=invalidsignature',
+      'whsec_test_secret'
+    );
+    expect(isValid).toBe(false);
+  });
+});
+
+describe('verifyWebhookSignature', () => {
+  it('タイムスタンプが古すぎる場合はfalseを返す', async () => {
+    // 10分前のタイムスタンプ（有効期限5分）
+    const oldTimestamp = Math.floor(Date.now() / 1000) - 600;
+    const isValid = await verifyWebhookSignature(
+      'payload',
+      `t=${oldTimestamp},v1=somesignature`,
+      'secret'
+    );
+    expect(isValid).toBe(false);
+  });
+
+  it('署名フォーマットが不正な場合はfalseを返す', async () => {
+    const isValid = await verifyWebhookSignature('payload', 'invalidsignature', 'secret');
+    expect(isValid).toBe(false);
+  });
+});

--- a/apps/backend/src/routes/webhook/stripe.ts
+++ b/apps/backend/src/routes/webhook/stripe.ts
@@ -1,0 +1,102 @@
+/**
+ * Stripe Webhookエンドポイント
+ * POST /api/webhook/stripe
+ * Related: fun-050 (Stripe Webhookによる決済イベント受信), fun-051, bac-010
+ */
+
+import { Hono } from 'hono';
+import { verifyWebhookSignature, activateUserPlan, deactivateUserPlan } from '../../services/stripe';
+import type { AppEnv } from '../../types/app';
+import type { PlanType } from '../../services/stripe';
+
+const stripeWebhook = new Hono<AppEnv>();
+
+stripeWebhook.post('/', async (c) => {
+  const stripeSignature = c.req.header('stripe-signature');
+  const webhookSecret = c.env.STRIPE_WEBHOOK_SECRET;
+
+  if (!stripeSignature) {
+    return c.json({ error: 'Missing stripe-signature header' }, 400);
+  }
+
+  if (!webhookSecret) {
+    return c.json({ error: 'Webhook secret not configured' }, 500);
+  }
+
+  const rawBody = await c.req.text();
+
+  // 署名検証
+  const isValid = await verifyWebhookSignature(rawBody, stripeSignature, webhookSecret);
+  if (!isValid) {
+    return c.json({ error: 'Invalid webhook signature' }, 400);
+  }
+
+  let event: { type: string; data: { object: Record<string, unknown> } };
+  try {
+    event = JSON.parse(rawBody) as typeof event;
+  } catch {
+    return c.json({ error: 'Invalid JSON payload' }, 400);
+  }
+
+  const db = c.get('db');
+
+  try {
+    switch (event.type) {
+      case 'checkout.session.completed': {
+        // 決済成功：ユーザープランを有効化
+        const session = event.data.object as {
+          metadata?: { user_id?: string; plan?: string };
+          customer?: string;
+          payment_status?: string;
+        };
+
+        if (session.payment_status !== 'paid') {
+          break;
+        }
+
+        const userId = session.metadata?.user_id;
+        const plan = session.metadata?.plan as PlanType | undefined;
+        const stripeCustomerId = session.customer;
+
+        if (!userId || !plan || !stripeCustomerId) {
+          console.error('Webhook: missing metadata in checkout.session.completed', {
+            userId,
+            plan,
+            stripeCustomerId,
+          });
+          break;
+        }
+
+        await activateUserPlan(db, userId, plan, stripeCustomerId);
+        console.log(`プラン有効化: userId=${userId}, plan=${plan}`);
+        break;
+      }
+
+      case 'customer.subscription.deleted': {
+        // サブスクリプションキャンセル：FREEプランに戻す
+        const subscription = event.data.object as { customer?: string };
+        const stripeCustomerId = subscription.customer;
+
+        if (!stripeCustomerId) {
+          console.error('Webhook: missing customer in customer.subscription.deleted');
+          break;
+        }
+
+        await deactivateUserPlan(db, stripeCustomerId);
+        console.log(`プラン無効化: stripeCustomerId=${stripeCustomerId}`);
+        break;
+      }
+
+      default:
+        // 未処理のイベントは無視
+        break;
+    }
+
+    return c.json({ received: true });
+  } catch (error) {
+    console.error('Webhook processing error:', error);
+    return c.json({ error: 'Webhook processing failed' }, 500);
+  }
+});
+
+export default stripeWebhook;

--- a/apps/backend/src/services/stripe.test.ts
+++ b/apps/backend/src/services/stripe.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Stripeサービスのテスト
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { env } from 'cloudflare:test';
+import { drizzle } from 'drizzle-orm/d1';
+import { activateUserPlan, deactivateUserPlan } from './stripe';
+
+describe('activateUserPlan', () => {
+  beforeAll(async () => {
+    await env.DB.prepare(`
+      CREATE TABLE IF NOT EXISTS users (
+        id TEXT PRIMARY KEY,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        github_id INTEGER NOT NULL UNIQUE,
+        username TEXT NOT NULL,
+        email TEXT,
+        avatar_url TEXT,
+        plan TEXT NOT NULL DEFAULT 'FREE',
+        credits_remaining INTEGER NOT NULL DEFAULT 0,
+        stripe_customer_id TEXT UNIQUE,
+        subscription_expires_at TEXT
+      )
+    `).run();
+
+    await env.DB.prepare(
+      `INSERT OR IGNORE INTO users (
+        id, created_at, updated_at, github_id, username, plan, credits_remaining
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`
+    )
+      .bind(
+        'stripe-service-test-user',
+        new Date().toISOString(),
+        new Date().toISOString(),
+        999003,
+        'stripeserviceuser',
+        'FREE',
+        0
+      )
+      .run();
+  });
+
+  it('ユーザーのプランをPROに更新する', async () => {
+    const db = drizzle(env.DB);
+
+    await activateUserPlan(db, 'stripe-service-test-user', 'PRO', 'cus_test_123');
+
+    const result = await env.DB.prepare(
+      'SELECT plan, stripe_customer_id, subscription_expires_at FROM users WHERE id = ?'
+    )
+      .bind('stripe-service-test-user')
+      .first<{ plan: string; stripe_customer_id: string; subscription_expires_at: string }>();
+
+    expect(result).not.toBeNull();
+    expect(result?.plan).toBe('PRO');
+    expect(result?.stripe_customer_id).toBe('cus_test_123');
+    expect(result?.subscription_expires_at).toBeTruthy();
+  });
+
+  it('deactivateUserPlanでFREEプランに戻す', async () => {
+    const db = drizzle(env.DB);
+
+    await deactivateUserPlan(db, 'cus_test_123');
+
+    const result = await env.DB.prepare(
+      'SELECT plan, subscription_expires_at FROM users WHERE id = ?'
+    )
+      .bind('stripe-service-test-user')
+      .first<{ plan: string; subscription_expires_at: string | null }>();
+
+    expect(result).not.toBeNull();
+    expect(result?.plan).toBe('FREE');
+    expect(result?.subscription_expires_at).toBeNull();
+  });
+});

--- a/apps/backend/src/services/stripe.ts
+++ b/apps/backend/src/services/stripe.ts
@@ -1,0 +1,176 @@
+/**
+ * Stripeサービス
+ * Stripe APIとの連携処理
+ * Related: fun-049, fun-050, fun-051
+ */
+
+import type { DrizzleD1Database } from 'drizzle-orm/d1';
+import { eq } from 'drizzle-orm';
+import { users } from '../db/schema';
+
+export type PlanType = 'PRO' | 'ENTERPRISE';
+
+export interface CheckoutSessionParams {
+  userId: string;
+  plan: PlanType;
+  stripeSecretKey: string;
+  stripePriceId: string;
+  successUrl: string;
+  cancelUrl: string;
+}
+
+export interface CheckoutSessionResult {
+  sessionId: string;
+  url: string;
+}
+
+export interface StripeWebhookEvent {
+  id: string;
+  type: string;
+  data: {
+    object: Record<string, unknown>;
+  };
+}
+
+/**
+ * Stripe Checkoutセッションを生成する
+ * fun-049: Stripe Checkoutセッション生成・リダイレクト
+ */
+export async function createCheckoutSession(
+  params: CheckoutSessionParams
+): Promise<CheckoutSessionResult> {
+  const { userId, stripeSecretKey, stripePriceId, successUrl, cancelUrl } = params;
+
+  const body = new URLSearchParams({
+    'line_items[0][price]': stripePriceId,
+    'line_items[0][quantity]': '1',
+    mode: 'subscription',
+    success_url: successUrl,
+    cancel_url: cancelUrl,
+    'metadata[user_id]': userId,
+    'metadata[plan]': params.plan,
+  });
+
+  const response = await fetch('https://api.stripe.com/v1/checkout/sessions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${stripeSecretKey}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    const error = await response.json() as { error?: { message?: string } };
+    throw new Error(`Stripe API error: ${error.error?.message ?? response.statusText}`);
+  }
+
+  const session = await response.json() as { id: string; url: string };
+  return {
+    sessionId: session.id,
+    url: session.url,
+  };
+}
+
+/**
+ * Stripe Webhookの署名を検証する
+ * fun-050: Stripe Webhookによる決済イベント受信
+ */
+export async function verifyWebhookSignature(
+  payload: string,
+  signature: string,
+  webhookSecret: string
+): Promise<boolean> {
+  // Stripe署名フォーマット: t=タイムスタンプ,v1=署名
+  const parts = signature.split(',');
+  const timestampPart = parts.find((p) => p.startsWith('t='));
+  const signaturePart = parts.find((p) => p.startsWith('v1='));
+
+  if (!timestampPart || !signaturePart) {
+    return false;
+  }
+
+  const timestamp = timestampPart.split('=')[1];
+  const expectedSignature = signaturePart.split('=')[1];
+
+  // HMAC-SHA256で署名を生成
+  const signedPayload = `${timestamp}.${payload}`;
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(webhookSecret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+
+  const signatureBuffer = await crypto.subtle.sign('HMAC', key, encoder.encode(signedPayload));
+  const computedSignature = Array.from(new Uint8Array(signatureBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+  // タイミング安全な比較
+  if (computedSignature.length !== expectedSignature.length) {
+    return false;
+  }
+
+  let isValid = true;
+  for (let i = 0; i < computedSignature.length; i++) {
+    if (computedSignature[i] !== expectedSignature[i]) {
+      isValid = false;
+    }
+  }
+
+  // 5分以内のリクエストのみ受け付ける（リプレイ攻撃対策）
+  const webhookTimestamp = parseInt(timestamp, 10);
+  const currentTime = Math.floor(Date.now() / 1000);
+  if (Math.abs(currentTime - webhookTimestamp) > 300) {
+    return false;
+  }
+
+  return isValid;
+}
+
+/**
+ * 決済成功時にユーザープランを更新する
+ * fun-051: 決済成功時のユーザー課金プラン有効化処理
+ */
+export async function activateUserPlan(
+  db: DrizzleD1Database,
+  userId: string,
+  plan: PlanType,
+  stripeCustomerId: string
+): Promise<void> {
+  // サブスクリプション有効期限を1ヶ月後に設定
+  const expiresAt = new Date();
+  expiresAt.setMonth(expiresAt.getMonth() + 1);
+
+  await db
+    .update(users)
+    .set({
+      plan,
+      stripeCustomerId,
+      subscriptionExpiresAt: expiresAt.toISOString(),
+      updatedAt: new Date().toISOString(),
+    })
+    .where(eq(users.id, userId))
+    .run();
+}
+
+/**
+ * サブスクリプションキャンセル時にユーザーをFREEプランに戻す
+ */
+export async function deactivateUserPlan(
+  db: DrizzleD1Database,
+  stripeCustomerId: string
+): Promise<void> {
+  await db
+    .update(users)
+    .set({
+      plan: 'FREE',
+      subscriptionExpiresAt: null,
+      updatedAt: new Date().toISOString(),
+    })
+    .where(eq(users.stripeCustomerId, stripeCustomerId))
+    .run();
+}

--- a/apps/backend/src/types/bindings.ts
+++ b/apps/backend/src/types/bindings.ts
@@ -15,4 +15,9 @@ export type Bindings = {
   REDIRECT_URI?: string;
   // フロントエンドURL（デフォルト: http://localhost:4321）
   FRONTEND_URL?: string;
+  // Stripe
+  STRIPE_SECRET_KEY?: string;
+  STRIPE_WEBHOOK_SECRET?: string;
+  STRIPE_PRICE_PRO?: string;
+  STRIPE_PRICE_ENTERPRISE?: string;
 };

--- a/apps/frontend/src/components/PricingTable.tsx
+++ b/apps/frontend/src/components/PricingTable.tsx
@@ -1,0 +1,124 @@
+/**
+ * PricingTable Component (scr-008)
+ * プラン比較表と課金ボタン
+ * Related: fun-049 (Stripe Checkoutセッション生成・リダイレクト)
+ */
+
+import { useState } from 'react';
+import type { PlanDetail } from '@gh-trend-tracker/shared';
+
+const PLANS: PlanDetail[] = [
+  {
+    id: 'PRO',
+    name: 'PRO',
+    priceLabel: '¥500 / 月',
+    features: [
+      'AIリポジトリ要約（無制限）',
+      'トレンドランキング全件表示',
+      '週別・月別詳細分析',
+      'メールサポート',
+    ],
+  },
+  {
+    id: 'ENTERPRISE',
+    name: 'ENTERPRISE',
+    priceLabel: '¥2,000 / 月',
+    features: [
+      'PROプランの全機能',
+      'チーム共有機能',
+      'API外部アクセス',
+      '優先サポート',
+    ],
+  },
+];
+
+interface PricingTableProps {
+  isAuthenticated: boolean;
+  currentPlan?: string;
+}
+
+export default function PricingTable({ isAuthenticated, currentPlan }: PricingTableProps) {
+  const [loading, setLoading] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const API_BASE = (import.meta as { env: Record<string, string> }).env.PUBLIC_API_URL || 'http://localhost:8787';
+
+  async function handlePlanSelect(planId: 'PRO' | 'ENTERPRISE') {
+    if (!isAuthenticated) {
+      window.location.href = `${API_BASE}/api/auth/login/github`;
+      return;
+    }
+
+    setLoading(planId);
+    setError(null);
+
+    try {
+      const response = await fetch(`${API_BASE}/api/billing/checkout`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ plan: planId }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json() as { error?: string };
+        throw new Error(data.error ?? 'チェックアウトの開始に失敗しました');
+      }
+
+      const data = await response.json() as { url: string };
+      window.location.href = data.url;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '予期しないエラーが発生しました');
+      setLoading(null);
+    }
+  }
+
+  return (
+    <div className="pricing-table">
+      {error && (
+        <div className="pricing-table__error" role="alert">
+          {error}
+        </div>
+      )}
+      <div className="pricing-table__plans">
+        {PLANS.map((plan) => {
+          const isCurrent = currentPlan === plan.id;
+          const isLoading = loading === plan.id;
+
+          return (
+            <div
+              key={plan.id}
+              className={`pricing-card ${plan.id === 'PRO' ? 'pricing-card--featured' : ''}`}
+            >
+              <div className="pricing-card__header">
+                <h2 className="pricing-card__name">{plan.name}</h2>
+                <p className="pricing-card__price">{plan.priceLabel}</p>
+              </div>
+              <ul className="pricing-card__features">
+                {plan.features.map((feature) => (
+                  <li key={feature} className="pricing-card__feature">
+                    <span className="pricing-card__check" aria-hidden="true">✓</span>
+                    {feature}
+                  </li>
+                ))}
+              </ul>
+              <div className="pricing-card__action">
+                {isCurrent ? (
+                  <span className="pricing-card__badge">現在のプラン</span>
+                ) : (
+                  <button
+                    className={`pricing-card__button ${plan.id === 'PRO' ? 'pricing-card__button--primary' : 'pricing-card__button--secondary'}`}
+                    onClick={() => handlePlanSelect(plan.id)}
+                    disabled={isLoading || loading !== null}
+                  >
+                    {isLoading ? '処理中...' : isAuthenticated ? 'このプランを選択' : 'GitHubでログインして開始'}
+                  </button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/billing/cancel.astro
+++ b/apps/frontend/src/pages/billing/cancel.astro
@@ -1,0 +1,96 @@
+---
+/**
+ * Payment Cancel Page (scr-009)
+ * 決済キャンセル・失敗画面
+ * Related: fun-049
+ */
+import Layout from '../../layouts/Layout.astro';
+
+const pageTitle = '決済キャンセル';
+---
+
+<Layout title={pageTitle}>
+  <main class="container">
+    <div class="result-page result-page--cancel">
+      <div class="result-page__icon" aria-hidden="true">✕</div>
+      <h1 class="result-page__title">決済がキャンセルされました</h1>
+      <p class="result-page__message">
+        決済処理がキャンセルされました。再度お試しいただくか、料金プランページからご確認ください。
+      </p>
+      <div class="result-page__actions">
+        <a href="/pricing" class="result-page__button result-page__button--primary">
+          料金プランを見る
+        </a>
+        <a href="/" class="result-page__button result-page__button--secondary">
+          トップに戻る
+        </a>
+      </div>
+    </div>
+  </main>
+</Layout>
+
+<style>
+  .container {
+    max-width: 600px;
+    margin: 0 auto;
+    padding: 0 1rem;
+  }
+
+  .result-page {
+    text-align: center;
+    padding: 4rem 2rem;
+  }
+
+  .result-page__icon {
+    font-size: 4rem;
+    line-height: 1;
+    margin-bottom: 1.5rem;
+  }
+
+  .result-page--cancel .result-page__icon {
+    color: #ef4444;
+  }
+
+  .result-page__title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+  }
+
+  .result-page__message {
+    color: var(--color-text-secondary, #6b7280);
+    margin-bottom: 2rem;
+    font-size: 1.05rem;
+  }
+
+  .result-page__actions {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .result-page__button {
+    display: inline-block;
+    padding: 0.75rem 1.5rem;
+    border-radius: 0.5rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: opacity 0.2s;
+  }
+
+  .result-page__button:hover {
+    opacity: 0.85;
+  }
+
+  .result-page__button--primary {
+    background-color: var(--color-primary, #6366f1);
+    color: #fff;
+  }
+
+  .result-page__button--secondary {
+    background-color: transparent;
+    color: var(--color-text, #374151);
+    border: 1px solid var(--color-border, #d1d5db);
+  }
+</style>

--- a/apps/frontend/src/pages/billing/success.astro
+++ b/apps/frontend/src/pages/billing/success.astro
@@ -1,0 +1,87 @@
+---
+/**
+ * Payment Success Page (scr-009)
+ * 決済成功画面
+ * Related: fun-049, fun-051
+ */
+import Layout from '../../layouts/Layout.astro';
+
+const pageTitle = '決済完了';
+---
+
+<Layout title={pageTitle}>
+  <main class="container">
+    <div class="result-page result-page--success">
+      <div class="result-page__icon" aria-hidden="true">✓</div>
+      <h1 class="result-page__title">決済が完了しました</h1>
+      <p class="result-page__message">
+        プランの有効化が完了しました。プレミアム機能をお楽しみください。
+      </p>
+      <div class="result-page__actions">
+        <a href="/" class="result-page__button result-page__button--primary">
+          トレンドを見る
+        </a>
+      </div>
+    </div>
+  </main>
+</Layout>
+
+<style>
+  .container {
+    max-width: 600px;
+    margin: 0 auto;
+    padding: 0 1rem;
+  }
+
+  .result-page {
+    text-align: center;
+    padding: 4rem 2rem;
+  }
+
+  .result-page__icon {
+    font-size: 4rem;
+    line-height: 1;
+    margin-bottom: 1.5rem;
+  }
+
+  .result-page--success .result-page__icon {
+    color: #22c55e;
+  }
+
+  .result-page__title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+  }
+
+  .result-page__message {
+    color: var(--color-text-secondary, #6b7280);
+    margin-bottom: 2rem;
+    font-size: 1.05rem;
+  }
+
+  .result-page__actions {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .result-page__button {
+    display: inline-block;
+    padding: 0.75rem 1.5rem;
+    border-radius: 0.5rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: opacity 0.2s;
+  }
+
+  .result-page__button:hover {
+    opacity: 0.85;
+  }
+
+  .result-page__button--primary {
+    background-color: var(--color-primary, #6366f1);
+    color: #fff;
+  }
+</style>

--- a/apps/frontend/src/pages/pricing.astro
+++ b/apps/frontend/src/pages/pricing.astro
@@ -1,0 +1,81 @@
+---
+/**
+ * Pricing Page (scr-008)
+ * プラン比較・選択画面
+ * Related: fun-049 (Stripe Checkoutセッション生成・リダイレクト)
+ */
+import Layout from '../layouts/Layout.astro';
+import PricingTable from '../components/PricingTable';
+
+const pageTitle = '料金プラン';
+
+// サーバーサイドでのユーザー認証確認（Cookie経由）
+const cookieHeader = Astro.request.headers.get('cookie') ?? '';
+const authToken = cookieHeader
+  .split(';')
+  .map((c) => c.trim())
+  .find((c) => c.startsWith('auth_token='))
+  ?.split('=')[1];
+
+const isAuthenticated = !!authToken;
+---
+
+<Layout title={pageTitle}>
+  <main class="container">
+    <div class="pricing-page">
+      <div class="pricing-page__header">
+        <h1 class="pricing-page__title">料金プラン</h1>
+        <p class="pricing-page__subtitle">
+          GitHubトレンドをより深く分析するためのプレミアム機能をご利用ください
+        </p>
+      </div>
+      <PricingTable
+        client:load
+        isAuthenticated={isAuthenticated}
+      />
+      <div class="pricing-page__note">
+        <p>※ お支払いはStripeによる安全な決済で処理されます</p>
+        <p>※ サブスクリプションはいつでもキャンセル可能です</p>
+      </div>
+    </div>
+  </main>
+</Layout>
+
+<style>
+  .container {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 0 1rem;
+  }
+
+  .pricing-page {
+    padding: 2rem 0;
+  }
+
+  .pricing-page__header {
+    text-align: center;
+    margin-bottom: 3rem;
+  }
+
+  .pricing-page__title {
+    font-size: 2rem;
+    font-weight: 700;
+    margin-bottom: 0.75rem;
+  }
+
+  .pricing-page__subtitle {
+    color: var(--color-text-secondary, #6b7280);
+    font-size: 1.1rem;
+  }
+
+  .pricing-page__note {
+    margin-top: 2rem;
+    text-align: center;
+    color: var(--color-text-secondary, #6b7280);
+    font-size: 0.875rem;
+  }
+
+  .pricing-page__note p {
+    margin: 0.25rem 0;
+  }
+</style>

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -1434,3 +1434,130 @@ input:focus {
   border: 0;
   border-top: 1px solid #e1e4e8;
 }
+
+/* ===== 料金プラン ===== */
+
+.pricing-table {
+  width: 100%;
+}
+
+.pricing-table__error {
+  background: #fef2f2;
+  color: #dc2626;
+  border: 1px solid #fecaca;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.pricing-table__plans {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.pricing-card {
+  background: #fff;
+  border: 1px solid #e1e4e8;
+  border-radius: 0.75rem;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  transition: box-shadow 0.2s;
+}
+
+.pricing-card:hover {
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+}
+
+.pricing-card--featured {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+}
+
+.pricing-card__header {
+  text-align: center;
+}
+
+.pricing-card__name {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.pricing-card__price {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #6366f1;
+}
+
+.pricing-card__features {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  flex: 1;
+}
+
+.pricing-card__feature {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  font-size: 0.9375rem;
+}
+
+.pricing-card__check {
+  color: #22c55e;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.pricing-card__action {
+  text-align: center;
+}
+
+.pricing-card__button {
+  display: inline-block;
+  width: 100%;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  font-size: 0.9375rem;
+  cursor: pointer;
+  border: none;
+  transition: opacity 0.2s;
+}
+
+.pricing-card__button:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.pricing-card__button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.pricing-card__button--primary {
+  background-color: #6366f1;
+  color: #fff;
+}
+
+.pricing-card__button--secondary {
+  background-color: transparent;
+  color: #374151;
+  border: 1px solid #d1d5db;
+}
+
+.pricing-card__badge {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  background: #f3f4f6;
+  color: #6b7280;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -35,3 +35,10 @@ export type {
   GitHubTokenResponse,
   AuthCallbackError,
 } from './types/auth';
+
+export type {
+  PlanType,
+  CheckoutRequest,
+  CheckoutResponse,
+  PlanDetail,
+} from './types/billing';

--- a/shared/src/types/billing.ts
+++ b/shared/src/types/billing.ts
@@ -1,0 +1,26 @@
+/**
+ * 課金関連の型定義
+ * Related: fun-049, fun-050, fun-051
+ */
+
+/** 利用可能なプランの種類 */
+export type PlanType = 'FREE' | 'PRO' | 'ENTERPRISE';
+
+/** Checkout セッション生成リクエスト */
+export type CheckoutRequest = {
+  plan: 'PRO' | 'ENTERPRISE';
+};
+
+/** Checkout セッション生成レスポンス */
+export type CheckoutResponse = {
+  url: string;
+  sessionId: string;
+};
+
+/** プランの詳細情報 */
+export type PlanDetail = {
+  id: 'PRO' | 'ENTERPRISE';
+  name: string;
+  priceLabel: string;
+  features: string[];
+};


### PR DESCRIPTION
- POST /api/billing/checkout: Stripe Checkoutセッション生成（bac-009）
- POST /api/webhook/stripe: 決済イベント受信・プラン有効化（bac-010）
- StripeサービスにHMAC-SHA256署名検証・プラン更新処理を実装
- PricingTable（scr-008）・決済成功/キャンセル画面（scr-009）を追加
- Bindings型にStripe環境変数を追加
- 共有型にBilling関連の型定義を追加