### PR TITLE
feat: 監視・ログ基盤構築

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -19,12 +19,17 @@ import billingCheckout from './routes/billing/checkout';
 import stripeWebhook from './routes/webhook/stripe';
 import { dbMiddleware } from './middleware/database';
 import { rateLimitMiddleware } from './middleware/rate-limit';
+import { loggingMiddleware } from './middleware/logging';
 import { runDailyCollection } from './services/batch-collector';
 import { runMetricsCalculation } from './services/metrics-calculator';
 import { runWeeklyRankingCalculation } from './services/weekly-ranking-calculator';
+import { logger } from './utils/logger';
 import type { AppEnv } from './types/app';
 
 const app = new Hono<AppEnv>();
+
+// リクエストログミドルウェア（全ルートに適用）
+app.use('/*', loggingMiddleware);
 
 // CORS設定（環境変数で許可オリジンを制御）
 // 本番環境: ALLOWED_ORIGINS環境変数を設定してオリジンを制限すること
@@ -77,34 +82,71 @@ export default {
 
         if (event.cron === '30 0 * * *') {
           // メトリクス計算（UTC 0:30）
+          const batchStart = Date.now();
           try {
             const result = await runMetricsCalculation({ db });
-            console.log('メトリクス計算結果:', JSON.stringify(result));
+            logger.info('batch_completed', {
+              batch: 'calculate-metrics',
+              cron: event.cron,
+              duration_ms: Date.now() - batchStart,
+              result,
+            });
           } catch (error) {
-            console.error('メトリクス計算エラー:', error);
+            logger.error('batch_failed', {
+              batch: 'calculate-metrics',
+              cron: event.cron,
+              duration_ms: Date.now() - batchStart,
+              error: String(error),
+            });
           }
         } else if (event.cron === '0 1 * * 1') {
           // 週別ランキング集計（毎週月曜 UTC 1:00）
+          const batchStart = Date.now();
           try {
             const result = await runWeeklyRankingCalculation({ db });
-            console.log('週別ランキング集計結果:', JSON.stringify(result));
+            logger.info('batch_completed', {
+              batch: 'calculate-weekly',
+              cron: event.cron,
+              duration_ms: Date.now() - batchStart,
+              result,
+            });
           } catch (error) {
-            console.error('週別ランキング集計エラー:', error);
+            logger.error('batch_failed', {
+              batch: 'calculate-weekly',
+              cron: event.cron,
+              duration_ms: Date.now() - batchStart,
+              error: String(error),
+            });
           }
         } else {
           // 日次データ収集（UTC 0:00）
           const githubToken = env.GITHUB_TOKEN;
 
           if (!githubToken) {
-            console.error('GITHUB_TOKEN環境変数が設定されていません');
+            logger.error('batch_failed', {
+              batch: 'collect-daily',
+              cron: event.cron,
+              error: 'GITHUB_TOKEN環境変数が設定されていません',
+            });
             return;
           }
 
+          const batchStart = Date.now();
           try {
             const result = await runDailyCollection({ db, githubToken });
-            console.log('スケジュール実行結果:', JSON.stringify(result));
+            logger.info('batch_completed', {
+              batch: 'collect-daily',
+              cron: event.cron,
+              duration_ms: Date.now() - batchStart,
+              result,
+            });
           } catch (error) {
-            console.error('スケジュール実行エラー:', error);
+            logger.error('batch_failed', {
+              batch: 'collect-daily',
+              cron: event.cron,
+              duration_ms: Date.now() - batchStart,
+              error: String(error),
+            });
           }
         }
       })()

--- a/apps/backend/src/middleware/logging.test.ts
+++ b/apps/backend/src/middleware/logging.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Hono } from 'hono';
+
+vi.mock('../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { loggingMiddleware } from './logging';
+import { logger } from '../utils/logger';
+
+describe('loggingMiddleware', () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = new Hono();
+    app.use('/*', loggingMiddleware);
+    app.get('/api/test', (c) => c.json({ ok: true }));
+    app.get('/api/bad-request', (c) => c.json({ error: 'bad' }, 400));
+    app.get('/api/server-error', (c) => c.json({ error: 'server' }, 500));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('200レスポンス時にinfoログが出力される', async () => {
+    const res = await app.request('/api/test');
+    expect(res.status).toBe(200);
+    expect(logger.info).toHaveBeenCalledOnce();
+    const [message, fields] = (logger.info as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(message).toBe('api_request');
+    expect(fields.method).toBe('GET');
+    expect(fields.path).toBe('/api/test');
+    expect(fields.status).toBe(200);
+    expect(typeof fields.duration_ms).toBe('number');
+  });
+
+  it('400レスポンス時にwarnログが出力される', async () => {
+    const res = await app.request('/api/bad-request');
+    expect(res.status).toBe(400);
+    expect(logger.warn).toHaveBeenCalledOnce();
+    const [message, fields] = (logger.warn as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(message).toBe('api_request');
+    expect(fields.status).toBe(400);
+  });
+
+  it('500レスポンス時にerrorログが出力される', async () => {
+    const res = await app.request('/api/server-error');
+    expect(res.status).toBe(500);
+    expect(logger.error).toHaveBeenCalledOnce();
+    const [message, fields] = (logger.error as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(message).toBe('api_request');
+    expect(fields.status).toBe(500);
+  });
+});

--- a/apps/backend/src/middleware/logging.ts
+++ b/apps/backend/src/middleware/logging.ts
@@ -1,0 +1,26 @@
+/**
+ * リクエスト/レスポンスのログミドルウェア
+ * 各APIリクエストの処理時間・ステータスを構造化ログとして出力する
+ */
+import { createMiddleware } from 'hono/factory';
+import { logger } from '../utils/logger';
+import type { AppEnv } from '../types/app';
+
+export const loggingMiddleware = createMiddleware<AppEnv>(async (c, next) => {
+  const start = Date.now();
+  const method = c.req.method;
+  const path = new URL(c.req.url).pathname;
+
+  await next();
+
+  const duration_ms = Date.now() - start;
+  const status = c.res.status;
+
+  if (status >= 500) {
+    logger.error('api_request', { method, path, status, duration_ms });
+  } else if (status >= 400) {
+    logger.warn('api_request', { method, path, status, duration_ms });
+  } else {
+    logger.info('api_request', { method, path, status, duration_ms });
+  }
+});

--- a/apps/backend/src/routes/health.ts
+++ b/apps/backend/src/routes/health.ts
@@ -10,13 +10,16 @@ health.get('/', async (c) => {
 
   try {
     const db = c.get('db');
+    const dbStart = Date.now();
     // 軽量なクエリでDB接続確認
     await db.run(sql`SELECT 1`);
+    const dbLatency_ms = Date.now() - dbStart;
 
     const response: HealthResponse = {
       status: 'ok',
       timestamp,
       database: 'connected',
+      dbLatency_ms,
     };
     return c.json(response);
   } catch (error) {

--- a/apps/backend/src/utils/logger.test.ts
+++ b/apps/backend/src/utils/logger.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { logger } from './logger';
+
+describe('logger', () => {
+  let consoleSpy: {
+    log: ReturnType<typeof vi.spyOn>;
+    warn: ReturnType<typeof vi.spyOn>;
+    error: ReturnType<typeof vi.spyOn>;
+  };
+
+  beforeEach(() => {
+    consoleSpy = {
+      log: vi.spyOn(console, 'log').mockImplementation(() => {}),
+      warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+      error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('info: JSON形式で出力される', () => {
+    logger.info('api_request', { method: 'GET', path: '/health', status: 200 });
+    expect(consoleSpy.log).toHaveBeenCalledOnce();
+    const entry = JSON.parse(consoleSpy.log.mock.calls[0][0] as string);
+    expect(entry.level).toBe('info');
+    expect(entry.message).toBe('api_request');
+    expect(entry.method).toBe('GET');
+    expect(entry.status).toBe(200);
+    expect(entry.timestamp).toBeDefined();
+  });
+
+  it('warn: console.warnに出力される', () => {
+    logger.warn('rate_limit', { path: '/api/trends/daily' });
+    expect(consoleSpy.warn).toHaveBeenCalledOnce();
+    const entry = JSON.parse(consoleSpy.warn.mock.calls[0][0] as string);
+    expect(entry.level).toBe('warn');
+  });
+
+  it('error: console.errorに出力される', () => {
+    logger.error('batch_failed', { batch: 'collect-daily', error: 'timeout' });
+    expect(consoleSpy.error).toHaveBeenCalledOnce();
+    const entry = JSON.parse(consoleSpy.error.mock.calls[0][0] as string);
+    expect(entry.level).toBe('error');
+    expect(entry.batch).toBe('collect-daily');
+  });
+
+  it('追加フィールドなしで呼び出せる', () => {
+    logger.info('simple_message');
+    expect(consoleSpy.log).toHaveBeenCalledOnce();
+    const entry = JSON.parse(consoleSpy.log.mock.calls[0][0] as string);
+    expect(entry.message).toBe('simple_message');
+  });
+});

--- a/apps/backend/src/utils/logger.ts
+++ b/apps/backend/src/utils/logger.ts
@@ -1,0 +1,59 @@
+/**
+ * 構造化ログユーティリティ
+ * Cloudflare Workers環境向けの軽量ロガー
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export type LogEntry = {
+  level: LogLevel;
+  timestamp: string;
+  message: string;
+  [key: string]: unknown;
+};
+
+const LOG_LEVELS: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+// 本番環境では 'info' 以上のみ出力
+const currentLevel: LogLevel = 'info';
+
+function createEntry(level: LogLevel, message: string, fields?: Record<string, unknown>): LogEntry {
+  return {
+    level,
+    timestamp: new Date().toISOString(),
+    message,
+    ...fields,
+  };
+}
+
+function output(level: LogLevel, entry: LogEntry): void {
+  if (LOG_LEVELS[level] < LOG_LEVELS[currentLevel]) return;
+  const line = JSON.stringify(entry);
+  if (level === 'error') {
+    console.error(line);
+  } else if (level === 'warn') {
+    console.warn(line);
+  } else {
+    console.log(line);
+  }
+}
+
+export const logger = {
+  debug(message: string, fields?: Record<string, unknown>): void {
+    output('debug', createEntry('debug', message, fields));
+  },
+  info(message: string, fields?: Record<string, unknown>): void {
+    output('info', createEntry('info', message, fields));
+  },
+  warn(message: string, fields?: Record<string, unknown>): void {
+    output('warn', createEntry('warn', message, fields));
+  },
+  error(message: string, fields?: Record<string, unknown>): void {
+    output('error', createEntry('error', message, fields));
+  },
+};

--- a/shared/src/types/api.ts
+++ b/shared/src/types/api.ts
@@ -75,6 +75,7 @@ export interface HealthResponse {
   status: 'ok' | 'unhealthy';
   timestamp: string;
   database: 'connected' | 'disconnected';
+  dbLatency_ms?: number;
 }
 
 export interface ErrorResponse {


### PR DESCRIPTION
## Summary

- 構造化ログユーティリティ (`apps/backend/src/utils/logger.ts`) を新規作成し、JSON形式でレベル別（info/warn/error/debug）に出力
- リクエスト/レスポンスのログミドルウェア (`apps/backend/src/middleware/logging.ts`) を新規作成し、全APIにリクエストログを追加
- ヘルスチェックエンドポイント (`/health`) にDBレイテンシ計測 (`dbLatency_ms`) を追加
- バッチ処理のログ（日次収集・メトリクス計算・週次ランキング）を構造化ロガーに統一

## Test plan

- [ ] `logger.info/warn/error` が JSON 形式で出力されることを確認（単体テスト）
- [ ] ログミドルウェアが 200/400/500 レスポンスで適切なログレベルを出力することを確認（単体テスト）
- [ ] `GET /health` が `dbLatency_ms` を含むレスポンスを返すことを確認
- [ ] バッチ処理実行時に構造化ログが出力されることを確認

## Changes

- `shared/src/types/api.ts` - `HealthResponse` に `dbLatency_ms?: number` を追加
- `apps/backend/src/utils/logger.ts` - 新規: 構造化ログユーティリティ
- `apps/backend/src/utils/logger.test.ts` - 新規: ロガーの単体テスト
- `apps/backend/src/middleware/logging.ts` - 新規: リクエストログミドルウェア
- `apps/backend/src/middleware/logging.test.ts` - 新規: ログミドルウェアの単体テスト
- `apps/backend/src/routes/health.ts` - DBレイテンシ計測を追加
- `apps/backend/src/index.ts` - ログミドルウェア組み込み・バッチログを構造化ロガーに統一

Closes #96