### PR TITLE
refactor: エラーハンドリング統一（logger経由 + traceId付与）

### DIFF
--- a/apps/backend/src/routes/auth/callback-github.ts
+++ b/apps/backend/src/routes/auth/callback-github.ts
@@ -4,6 +4,7 @@
  */
 
 import { Hono } from 'hono';
+import { logger } from '../../utils/logger';
 import { exchangeCodeForToken, fetchGitHubUser } from '../../services/github-auth';
 import { generateJwt } from '../../services/jwt';
 import { upsertUser } from '../../services/user-service';
@@ -100,14 +101,12 @@ callbackGithub.get('/', async (c) => {
     const frontendUrl = c.env.FRONTEND_URL ?? 'http://localhost:4321';
     return c.redirect(`${frontendUrl}/`);
   } catch (error) {
-    console.error('GitHub OAuth callback error:', error);
-    return c.json(
-      {
-        error: 'Authentication failed',
-        details: error instanceof Error ? error.message : 'Unknown error',
-      },
-      500
-    );
+    const traceId = crypto.randomUUID();
+    logger.error('auth_github_callback_failed', {
+      traceId,
+      errorMessage: error instanceof Error ? error.message : 'unknown',
+    });
+    return c.json({ error: 'Authentication failed', traceId }, 500);
   }
 });
 

--- a/apps/backend/src/routes/auth/me.ts
+++ b/apps/backend/src/routes/auth/me.ts
@@ -5,6 +5,7 @@
  */
 
 import { Hono } from 'hono';
+import { logger } from '../../utils/logger';
 import { authMiddleware } from '../../middleware/auth';
 import { findUserById } from '../../services/user-service';
 import type { AppEnv } from '../../types/app';
@@ -35,8 +36,13 @@ app.get('/', authMiddleware, async (c) => {
       plan: userInfo.plan,
     });
   } catch (error) {
-    console.error('Failed to get user info:', error);
-    return c.json({ error: 'Failed to get user info' }, 500);
+    const traceId = crypto.randomUUID();
+    logger.error('auth_me_fetch_failed', {
+      traceId,
+      userId: user.userId,
+      errorMessage: error instanceof Error ? error.message : 'unknown',
+    });
+    return c.json({ error: 'Failed to get user info', traceId }, 500);
   }
 });
 

--- a/apps/backend/src/routes/batch/calculate-metrics.ts
+++ b/apps/backend/src/routes/batch/calculate-metrics.ts
@@ -10,6 +10,7 @@ import type { AppEnv } from '../../types/app';
 import type { ApiError } from '@gh-trend-tracker/shared';
 import { internalAuthMiddleware } from '../../middleware/internal-auth';
 import { internalError } from '../../shared/errors';
+import { logger } from '../../utils/logger';
 import { runMetricsCalculation } from '../../services/metrics-calculator';
 
 const calculateMetrics = new Hono<AppEnv>();
@@ -24,8 +25,12 @@ calculateMetrics.post('/', async (c) => {
     const response = await runMetricsCalculation({ db });
     return c.json(response);
   } catch (error) {
-    console.error('メトリクス計算中の致命的エラー:', error);
-    const errorResponse: ApiError = internalError('Metrics calculation failed');
+    const traceId = crypto.randomUUID();
+    logger.error('batch_calculate_metrics_failed', {
+      traceId,
+      errorMessage: error instanceof Error ? error.message : 'unknown',
+    });
+    const errorResponse: ApiError = { ...internalError('Metrics calculation failed'), traceId };
     return c.json(errorResponse, 500);
   }
 });

--- a/apps/backend/src/routes/batch/calculate-weekly.ts
+++ b/apps/backend/src/routes/batch/calculate-weekly.ts
@@ -10,6 +10,7 @@ import type { AppEnv } from '../../types/app';
 import type { ApiError } from '@gh-trend-tracker/shared';
 import { internalAuthMiddleware } from '../../middleware/internal-auth';
 import { internalError } from '../../shared/errors';
+import { logger } from '../../utils/logger';
 import { runWeeklyRankingCalculation } from '../../services/weekly-ranking-calculator';
 
 const calculateWeekly = new Hono<AppEnv>();
@@ -24,8 +25,12 @@ calculateWeekly.post('/', async (c) => {
     const response = await runWeeklyRankingCalculation({ db });
     return c.json(response);
   } catch (error) {
-    console.error('週別ランキング集計中の致命的エラー:', error);
-    const errorResponse: ApiError = internalError('Weekly ranking calculation failed');
+    const traceId = crypto.randomUUID();
+    logger.error('batch_calculate_weekly_failed', {
+      traceId,
+      errorMessage: error instanceof Error ? error.message : 'unknown',
+    });
+    const errorResponse: ApiError = { ...internalError('Weekly ranking calculation failed'), traceId };
     return c.json(errorResponse, 500);
   }
 });

--- a/apps/backend/src/routes/batch/collect-daily.ts
+++ b/apps/backend/src/routes/batch/collect-daily.ts
@@ -13,6 +13,7 @@ import type { AppEnv } from '../../types/app';
 import type { ApiError } from '@gh-trend-tracker/shared';
 import { internalAuthMiddleware } from '../../middleware/internal-auth';
 import { internalError } from '../../shared/errors';
+import { logger } from '../../utils/logger';
 import { runDailyCollection } from '../../services/batch-collector';
 
 /** HTTPリクエスト経由のデフォルト処理件数（タイムアウト対策） */
@@ -28,7 +29,9 @@ collectDaily.post('/', async (c) => {
   const githubToken = c.env.GITHUB_TOKEN;
 
   if (!githubToken) {
-    console.error('GITHUB_TOKEN環境変数が設定されていません');
+    logger.error('batch_collect_daily_missing_token', {
+      errorMessage: 'GITHUB_TOKEN環境変数が設定されていません',
+    });
     const errorResponse: ApiError = internalError('GitHub token not configured');
     return c.json(errorResponse, 500);
   }
@@ -41,8 +44,12 @@ collectDaily.post('/', async (c) => {
     const response = await runDailyCollection({ db, githubToken, limit });
     return c.json(response);
   } catch (error) {
-    console.error('バッチ処理中の致命的エラー:', error);
-    const errorResponse: ApiError = internalError('Batch collection failed');
+    const traceId = crypto.randomUUID();
+    logger.error('batch_collect_daily_failed', {
+      traceId,
+      errorMessage: error instanceof Error ? error.message : 'unknown',
+    });
+    const errorResponse: ApiError = { ...internalError('Batch collection failed'), traceId };
     return c.json(errorResponse, 500);
   }
 });

--- a/apps/backend/src/routes/billing/checkout.ts
+++ b/apps/backend/src/routes/billing/checkout.ts
@@ -5,6 +5,7 @@
  */
 
 import { Hono } from 'hono';
+import { logger } from '../../utils/logger';
 import { authMiddleware } from '../../middleware/auth';
 import { createCheckoutSession } from '../../services/stripe';
 import type { AppEnv } from '../../types/app';
@@ -54,14 +55,14 @@ billingCheckout.post('/', authMiddleware, async (c) => {
 
     return c.json({ url: session.url, sessionId: session.sessionId });
   } catch (error) {
-    console.error('Stripe checkout error:', error);
-    return c.json(
-      {
-        error: 'Failed to create checkout session',
-        details: error instanceof Error ? error.message : 'Unknown error',
-      },
-      500
-    );
+    const traceId = crypto.randomUUID();
+    logger.error('billing_checkout_failed', {
+      traceId,
+      userId: user.userId,
+      plan,
+      errorMessage: error instanceof Error ? error.message : 'unknown',
+    });
+    return c.json({ error: 'Failed to create checkout session', traceId }, 500);
   }
 });
 

--- a/apps/backend/src/routes/health.ts
+++ b/apps/backend/src/routes/health.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { logger } from '../utils/logger';
 import { sql } from 'drizzle-orm';
 import type { HealthResponse } from '@gh-trend-tracker/shared';
 import type { AppEnv } from '../types/app';
@@ -23,7 +24,9 @@ health.get('/', async (c) => {
     };
     return c.json(response);
   } catch (error) {
-    console.error('Health check failed - database connection error:', error);
+    logger.error('health_check_db_failed', {
+      errorMessage: error instanceof Error ? error.message : 'unknown',
+    });
     const response: HealthResponse = {
       status: 'unhealthy',
       timestamp,

--- a/apps/backend/src/routes/languages.ts
+++ b/apps/backend/src/routes/languages.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { getAllLanguages } from '../shared/queries';
 import { dbError } from '../shared/errors';
+import { logger } from '../utils/logger';
 import type { LanguagesResponse, ApiError } from '@gh-trend-tracker/shared';
 import type { AppEnv } from '../types/app';
 
@@ -15,8 +16,12 @@ languages.get('/', async (c) => {
     const response: LanguagesResponse = { languages: languagesList };
     return c.json(response);
   } catch (error) {
-    console.error('Error fetching languages:', error);
-    const errorResponse: ApiError = dbError('Failed to fetch languages');
+    const traceId = crypto.randomUUID();
+    logger.error('languages_fetch_failed', {
+      traceId,
+      errorMessage: error instanceof Error ? error.message : 'unknown',
+    });
+    const errorResponse: ApiError = { ...dbError('Failed to fetch languages'), traceId };
     return c.json(errorResponse, 500);
   }
 });

--- a/apps/backend/src/routes/repositories-search.ts
+++ b/apps/backend/src/routes/repositories-search.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { logger } from '../utils/logger';
 import { like, or, desc, sql } from 'drizzle-orm';
 import { repositories, repoSnapshots } from '../db/schema';
 import { SearchQuerySchema } from '../schemas/search';
@@ -68,8 +69,13 @@ repositoriesSearch.get('/', async (c) => {
 
     return c.json(response);
   } catch (error) {
-    console.error('Error searching repositories:', error);
-    const errorResponse: ApiError = dbError('Failed to search repositories');
+    const traceId = crypto.randomUUID();
+    logger.error('repositories_search_failed', {
+      traceId,
+      searchQuery,
+      errorMessage: error instanceof Error ? error.message : 'unknown',
+    });
+    const errorResponse: ApiError = { ...dbError('Failed to search repositories'), traceId };
     return c.json(errorResponse, 500);
   }
 });

--- a/apps/backend/src/routes/repositories.ts
+++ b/apps/backend/src/routes/repositories.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { logger } from '../utils/logger';
 import { getRepositoryHistory, getRepositoryDetail } from '../shared/queries';
 import { DEFAULT_HISTORY_DAYS } from '../shared/constants';
 import { parsePositiveInt } from '../shared/utils';
@@ -33,8 +34,13 @@ repositories.get('/:repoId', async (c) => {
     const response: RepoDetailResponse = detail;
     return c.json(response);
   } catch (error) {
-    console.error('Error fetching repository detail:', error);
-    const errorResponse: ApiError = dbError('Failed to fetch repository detail');
+    const traceId = crypto.randomUUID();
+    logger.error('repository_detail_fetch_failed', {
+      traceId,
+      repoId,
+      errorMessage: error instanceof Error ? error.message : 'unknown',
+    });
+    const errorResponse: ApiError = { ...dbError('Failed to fetch repository detail'), traceId };
     return c.json(errorResponse, 500);
   }
 });
@@ -63,8 +69,13 @@ repositories.get('/:repoId/history', async (c) => {
     const response: HistoryResponse = { history };
     return c.json(response);
   } catch (error) {
-    console.error('Error fetching history:', error);
-    const errorResponse: ApiError = dbError('Failed to fetch history');
+    const traceId = crypto.randomUUID();
+    logger.error('repository_history_fetch_failed', {
+      traceId,
+      repoId,
+      errorMessage: error instanceof Error ? error.message : 'unknown',
+    });
+    const errorResponse: ApiError = { ...dbError('Failed to fetch history'), traceId };
     return c.json(errorResponse, 500);
   }
 });

--- a/apps/backend/src/routes/trends-daily.ts
+++ b/apps/backend/src/routes/trends-daily.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { logger } from '../utils/logger';
 import { eq, desc, and, sql } from 'drizzle-orm';
 import { repositories, metricsDaily, repoSnapshots } from '../db/schema';
 import { TrendsDailyQuerySchema } from '../schemas/trends';
@@ -136,8 +137,12 @@ trendsDaily.get('/', async (c) => {
 
     return c.json(response);
   } catch (error) {
-    console.error('Error fetching daily trends:', error);
-    const errorResponse: ApiError = dbError('Failed to fetch daily trends');
+    const traceId = crypto.randomUUID();
+    logger.error('trends_daily_fetch_failed', {
+      traceId,
+      errorMessage: error instanceof Error ? error.message : 'unknown',
+    });
+    const errorResponse: ApiError = { ...dbError('Failed to fetch daily trends'), traceId };
     return c.json(errorResponse, 500);
   }
 });

--- a/apps/backend/src/routes/trends-weekly-available.ts
+++ b/apps/backend/src/routes/trends-weekly-available.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { logger } from '../utils/logger';
 import { sql } from 'drizzle-orm';
 import { rankingWeekly } from '../db/schema';
 import { dbError } from '../shared/errors';
@@ -33,8 +34,12 @@ trendsWeeklyAvailable.get('/', async (c) => {
 
     return c.json(response);
   } catch (error) {
-    console.error('Error fetching available weeks:', error);
-    const errorResponse: ApiError = dbError('Failed to fetch available weeks');
+    const traceId = crypto.randomUUID();
+    logger.error('trends_weekly_available_fetch_failed', {
+      traceId,
+      errorMessage: error instanceof Error ? error.message : 'unknown',
+    });
+    const errorResponse: ApiError = { ...dbError('Failed to fetch available weeks'), traceId };
     return c.json(errorResponse, 500);
   }
 });

--- a/apps/backend/src/routes/trends-weekly.ts
+++ b/apps/backend/src/routes/trends-weekly.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { logger } from '../utils/logger';
 import { eq, and } from 'drizzle-orm';
 import { rankingWeekly } from '../db/schema';
 import { WeeklyTrendsQuerySchema } from '../schemas/weekly';
@@ -81,8 +82,12 @@ trendsWeekly.get('/', async (c) => {
 
     return c.json(response);
   } catch (error) {
-    console.error('Error fetching weekly trends:', error);
-    const errorResponse: ApiError = dbError('Failed to fetch weekly trends');
+    const traceId = crypto.randomUUID();
+    logger.error('trends_weekly_fetch_failed', {
+      traceId,
+      errorMessage: error instanceof Error ? error.message : 'unknown',
+    });
+    const errorResponse: ApiError = { ...dbError('Failed to fetch weekly trends'), traceId };
     return c.json(errorResponse, 500);
   }
 });

--- a/apps/backend/src/routes/webhook/stripe.ts
+++ b/apps/backend/src/routes/webhook/stripe.ts
@@ -5,6 +5,7 @@
  */
 
 import { Hono } from 'hono';
+import { logger } from '../../utils/logger';
 import { verifyWebhookSignature, activateUserPlan, deactivateUserPlan } from '../../services/stripe';
 import type { AppEnv } from '../../types/app';
 import type { PlanType } from '../../services/stripe';
@@ -59,7 +60,7 @@ stripeWebhook.post('/', async (c) => {
         const stripeCustomerId = session.customer;
 
         if (!userId || !plan || !stripeCustomerId) {
-          console.error('Webhook: missing metadata in checkout.session.completed', {
+          logger.error('webhook_checkout_missing_metadata', {
             userId,
             plan,
             stripeCustomerId,
@@ -68,7 +69,7 @@ stripeWebhook.post('/', async (c) => {
         }
 
         await activateUserPlan(db, userId, plan, stripeCustomerId);
-        console.log(`プラン有効化: userId=${userId}, plan=${plan}`);
+        logger.info('webhook_plan_activated', { userId, plan });
         break;
       }
 
@@ -78,12 +79,12 @@ stripeWebhook.post('/', async (c) => {
         const stripeCustomerId = subscription.customer;
 
         if (!stripeCustomerId) {
-          console.error('Webhook: missing customer in customer.subscription.deleted');
+          logger.error('webhook_subscription_missing_customer', {});
           break;
         }
 
         await deactivateUserPlan(db, stripeCustomerId);
-        console.log(`プラン無効化: stripeCustomerId=${stripeCustomerId}`);
+        logger.info('webhook_plan_deactivated', { stripeCustomerId });
         break;
       }
 
@@ -94,8 +95,12 @@ stripeWebhook.post('/', async (c) => {
 
     return c.json({ received: true });
   } catch (error) {
-    console.error('Webhook processing error:', error);
-    return c.json({ error: 'Webhook processing failed' }, 500);
+    const traceId = crypto.randomUUID();
+    logger.error('webhook_processing_failed', {
+      traceId,
+      errorMessage: error instanceof Error ? error.message : 'unknown',
+    });
+    return c.json({ error: 'Webhook processing failed', traceId }, 500);
   }
 });
 

--- a/docs/基本/開発ガイド.md
+++ b/docs/基本/開発ガイド.md
@@ -321,12 +321,36 @@ app.use('/*', cors());
 
 ### エラーハンドリング
 
-現在、全エンドポイントがエラーをキャッチし、汎用エラーメッセージで500を返します。
+全エンドポイントは `logger` ユーティリティ（`apps/backend/src/utils/logger.ts`）経由でエラーを記録します。
+各エラーには `traceId`（UUID）を付与し、ログとレスポンスの両方に含めることで本番運用でのエラー追跡を可能にします。
 
-本番環境では以下の対応が必要：
-- より具体的なエラーメッセージ
-- エラーログの記録
-- ユーザーフレンドリーなエラー表示
+#### logger の使い方
+
+```typescript
+import { logger } from '../utils/logger';
+
+// エラーログ（traceId必須）
+} catch (error) {
+  const traceId = crypto.randomUUID();
+  logger.error('endpoint_operation_failed', {
+    traceId,
+    // 状況に応じた追加コンテキスト（userId, repoId など）
+    errorMessage: error instanceof Error ? error.message : 'unknown',
+  });
+  const errorResponse: ApiError = { ...dbError('...'), traceId };
+  return c.json(errorResponse, 500);
+}
+
+// 情報ログ（任意のフィールドを追加）
+logger.info('operation_completed', { userId, plan });
+```
+
+#### ルール
+
+- **`console.*` は routes/ 配下では使用禁止**。必ず `logger` 経由で記録する
+- **エラーログには必ず `traceId` を付与**し、レスポンスボディにも含める
+- **内部エラー詳細（スタックトレース等）はレスポンスに含めない**。`traceId` のみ返す
+- **メッセージキー（第1引数）はスネークケース**で具体的に命名する（例: `trends_daily_fetch_failed`）
 
 ### クエリ制限
 


### PR DESCRIPTION
## Summary

- `routes/` 配下14ファイルの全 `console.*` を `logger` ユーティリティ経由に置き換え
- 各エラーに `crypto.randomUUID()` で生成した `traceId` を付与
- ログと JSON レスポンス両方に `traceId` を含め、内部エラー詳細をレスポンスから除去
- 開発ガイド（`docs/基本/開発ガイド.md`）に logger の使い方を追記

## Test plan

- [x] `npm run test:backend` 全122テスト通過
- [x] `npx tsc --noEmit` 型エラーなし
- [x] `routes/` 配下に `console.*` が残存しないことを確認
- [x] `ApiError` 型の `traceId` フィールドが既存型定義と整合していることを確認

## Changes

- `apps/backend/src/routes/` 配下14ファイルに `logger` import 追加、`console.*` をすべて `logger.error/info` に置換
- エラーキャッチブロックで `const traceId = crypto.randomUUID()` を発行し、ログと `ApiError` レスポンスに付与
- `billing/checkout.ts`・`auth/callback-github.ts` のレスポンスから `details` フィールド（内部エラー文字列）を除去
- `docs/基本/開発ガイド.md` の「エラーハンドリング」節を更新し、ルールとコード例を追記

Closes #133