### PR TITLE
refactor: BackendのtsonfigからJSX関連設定を除去

### DIFF
--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2022"],
-    "jsx": "react-jsx",
     "module": "ES2022",
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary
- `apps/backend/tsconfig.json` から不要な `jsx: react-jsx` 設定を削除
- BackendはCloudflare Workers環境でJSXを使用しないため、設定が不要

## Test plan
- [x] `npm run type-check`（Backend）が成功することを確認
- [x] バックエンドのテスト（23ファイル、140テスト）が全てパス
- [x] `npm run build`（全体）が成功することを確認

## Changes
- `apps/backend/tsconfig.json`: `jsx: react-jsx` を削除

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)