### PR TITLE
Fix weekly ranking baseline snapshot boundary

### DIFF
--- a/apps/backend/src/services/weekly-ranking-calculator.ts
+++ b/apps/backend/src/services/weekly-ranking-calculator.ts
@@ -3,7 +3,7 @@
  * HTTPエンドポイントとCronトリガーの両方から呼び出される
  */
 import type { DrizzleD1Database } from 'drizzle-orm/d1';
-import { eq, and, between, lte, desc } from 'drizzle-orm';
+import { eq, and, between, lte, lt, desc } from 'drizzle-orm';
 import type { BatchWeeklyRankingResponse, WeeklyRankEntry } from '@gh-trend-tracker/shared';
 import { repositories, repoSnapshots, rankingWeekly } from '../db/schema';
 
@@ -91,14 +91,15 @@ export async function runWeeklyRankingCalculation(
   }> = [];
 
   for (const repo of reposWithSnapshots) {
-    // 週開始日以前の最新スナップショット（開始時点のスター数）
+    // 週開始日より前の最新スナップショット（開始時点のスター数）
+    // NOTE: 週開始日当日のスナップショットを含めると、月曜の増加分が差分から漏れるため除外する
     const startSnap = await db
       .select({ stars: repoSnapshots.stars })
       .from(repoSnapshots)
       .where(
         and(
           eq(repoSnapshots.repoId, repo.repoId),
-          lte(repoSnapshots.snapshotDate, startDate)
+          lt(repoSnapshots.snapshotDate, startDate)
         )
       )
       .orderBy(desc(repoSnapshots.snapshotDate))

--- a/apps/backend/test/batch-calculate-weekly.spec.ts
+++ b/apps/backend/test/batch-calculate-weekly.spec.ts
@@ -186,7 +186,7 @@ describe('POST /api/internal/batch/calculate-weekly', () => {
 
   describe('週別ランキング集計', () => {
     // テスト用に前の週の月曜〜日曜のスナップショットデータを用意する
-    function getLastWeekDates(): { monday: string; sunday: string } {
+    function getLastWeekDates(): { previousSunday: string; monday: string; sunday: string } {
       const now = new Date();
       const lastWeek = new Date(now);
       lastWeek.setUTCDate(lastWeek.getUTCDate() - 7);
@@ -196,7 +196,10 @@ describe('POST /api/internal/batch/calculate-weekly', () => {
       monday.setUTCDate(lastWeek.getUTCDate() - dayOfWeek + 1);
       const sunday = new Date(monday);
       sunday.setUTCDate(monday.getUTCDate() + 6);
+      const previousSunday = new Date(monday);
+      previousSunday.setUTCDate(monday.getUTCDate() - 1);
       return {
+        previousSunday: previousSunday.toISOString().split('T')[0],
         monday: monday.toISOString().split('T')[0],
         sunday: sunday.toISOString().split('T')[0],
       };
@@ -204,12 +207,14 @@ describe('POST /api/internal/batch/calculate-weekly', () => {
 
     it('全言語のランキングが生成されること', async () => {
       const db = env.DB as D1Database;
-      const { monday, sunday } = getLastWeekDates();
+      const { previousSunday, monday, sunday } = getLastWeekDates();
 
       await insertRepo(db, 100, 'repo-a', 'TypeScript');
       await insertRepo(db, 101, 'repo-b', 'Python');
+      await insertSnapshot(db, 100, previousSunday, 1000);
       await insertSnapshot(db, 100, monday, 1000);
       await insertSnapshot(db, 100, sunday, 1500);
+      await insertSnapshot(db, 101, previousSunday, 2000);
       await insertSnapshot(db, 101, monday, 2000);
       await insertSnapshot(db, 101, sunday, 2300);
 
@@ -254,12 +259,14 @@ describe('POST /api/internal/batch/calculate-weekly', () => {
 
     it('言語別ランキングが正しく分離されること', async () => {
       const db = env.DB as D1Database;
-      const { monday, sunday } = getLastWeekDates();
+      const { previousSunday, monday, sunday } = getLastWeekDates();
 
       await insertRepo(db, 200, 'ts-repo', 'TypeScript');
       await insertRepo(db, 201, 'py-repo', 'Python');
+      await insertSnapshot(db, 200, previousSunday, 100);
       await insertSnapshot(db, 200, monday, 100);
       await insertSnapshot(db, 200, sunday, 300);
+      await insertSnapshot(db, 201, previousSunday, 500);
       await insertSnapshot(db, 201, monday, 500);
       await insertSnapshot(db, 201, sunday, 600);
 


### PR DESCRIPTION
### Motivation
- The weekly ranking calculation used a snapshot condition that included the week-start date, causing Monday star increases to be excluded from the computed weekly delta.
- Tests that seed snapshots for week calculations assumed a strict-before baseline and failed after the boundary logic was corrected, so test seeds needed to include the previous Sunday snapshot.

### Description
- Use `lt` instead of `lte` when selecting the baseline snapshot before the target week by importing `lt` from `drizzle-orm` and replacing the condition to `repoSnapshots.snapshotDate < startDate`.
- Add an inline comment explaining why snapshots on the week start must be excluded to avoid dropping Monday increases.
- Update `getLastWeekDates` in the affected integration tests to return a `previousSunday` value and seed `previousSunday` snapshots for repos in the weekly ranking tests so expected deltas match the corrected boundary behavior.

### Testing
- Ran frontend tests with `npm run test -w apps/frontend -- --run` and they passed (`4 passed`, `54 tests`).
- Ran backend tests with `npm run test -w apps/backend -- --run` and fixed failing cases; final run passed all tests (`23 test files`, `140 tests` passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faee2745d883289dbd5330db5fedd6)