### PR TITLE
feat(#150): wrangler.jsonc env分離とdev DBバインディング対応

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "deploy": "wrangler deploy",
-    "dev": "wrangler dev",
-    "start": "wrangler dev",
+    "deploy": "wrangler deploy --env production",
+    "dev": "wrangler dev --env development",
+    "start": "wrangler dev --env development",
     "test": "vitest",
     "type-check": "tsc --noEmit",
     "lint": "eslint .",

--- a/apps/backend/vitest.config.mts
+++ b/apps/backend/vitest.config.mts
@@ -8,6 +8,9 @@ export default defineConfig({
         configPath: './wrangler.jsonc',
       },
       miniflare: {
+        // wrangler.jsonc の d1_databases が env 以下にのみ定義されているため、
+        // デフォルト環境（テスト実行環境）向けに DB バインディングを明示的に追加
+        d1Databases: ['DB'],
         bindings: {
           INTERNAL_API_TOKEN: 'test-internal-token',
           GITHUB_CLIENT_ID: 'test-client-id',

--- a/apps/backend/wrangler.jsonc
+++ b/apps/backend/wrangler.jsonc
@@ -2,13 +2,21 @@
  * Cloudflare Workers設定
  * https://developers.cloudflare.com/workers/wrangler/configuration/
  *
- * CORS設定:
- * 本番環境では環境変数 ALLOWED_ORIGINS を設定してください。
- * カンマ区切りで複数のオリジンを指定可能です。
- * 例: npx wrangler secret put ALLOWED_ORIGINS
- *     値: https://example.com,https://app.example.com
+ * 環境構成:
+ *   development: ローカル開発用。開発D1（gh-trends-db-dev）を使用。
+ *                `wrangler dev --env development` で起動。
+ *   production:  本番環境。本番D1（gh-trends-db）を使用。
+ *                `wrangler deploy --env production` でデプロイ。
  *
- * 未設定の場合は全オリジンを許可します（開発用）。
+ * 初回セットアップ:
+ *   開発用D1を作成してから database_id を env.development に記入してください:
+ *   $ npx wrangler d1 create gh-trends-db-dev
+ *
+ * CORS設定:
+ *   本番環境では環境変数 ALLOWED_ORIGINS を設定してください。
+ *   カンマ区切りで複数のオリジンを指定可能です。
+ *   例: npx wrangler secret put ALLOWED_ORIGINS --env production
+ *       値: https://example.com,https://app.example.com
  */
 {
   "$schema": "node_modules/wrangler/config-schema.json",
@@ -22,20 +30,39 @@
   "observability": {
     "enabled": true,
   },
-  "d1_databases": [
-    {
-      "binding": "DB",
-      "database_name": "gh-trends-db",
-      "database_id": "a9fae3bf-ae66-43af-b167-d329c9e7154d",
+  "env": {
+    "development": {
+      /**
+       * 開発用D1データベース
+       * 初回セットアップ時に以下のコマンドを実行し、
+       * 出力された database_id をここに記入してください:
+       * $ npx wrangler d1 create gh-trends-db-dev
+       */
+      "d1_databases": [
+        {
+          "binding": "DB",
+          "database_name": "gh-trends-db-dev",
+          "database_id": "REPLACE_WITH_DEV_D1_DATABASE_ID",
+        },
+      ],
     },
-  ],
-  /**
-   * Cron Trigger設定
-   * - 毎日 UTC 0:00: 日次データ収集バッチを実行
-   * - 毎日 UTC 0:30: メトリクス計算バッチを実行（日次収集後）
-   * - 毎週月曜 UTC 1:00: 週別トレンドランキング集計を実行
-   */
-  "triggers": {
-    "crons": ["0 0 * * *", "30 0 * * *", "0 1 * * 1"],
+    "production": {
+      "d1_databases": [
+        {
+          "binding": "DB",
+          "database_name": "gh-trends-db",
+          "database_id": "a9fae3bf-ae66-43af-b167-d329c9e7154d",
+        },
+      ],
+      /**
+       * Cron Trigger設定（本番のみ）
+       * - 毎日 UTC 0:00: 日次データ収集バッチを実行
+       * - 毎日 UTC 0:30: メトリクス計算バッチを実行（日次収集後）
+       * - 毎週月曜 UTC 1:00: 週別トレンドランキング集計を実行
+       */
+      "triggers": {
+        "crons": ["0 0 * * *", "30 0 * * *", "0 1 * * 1"],
+      },
+    },
   },
 }

--- a/docs/基本/開発ガイド.md
+++ b/docs/基本/開発ガイド.md
@@ -39,12 +39,15 @@ npm run test
 # ルートから
 npm run build:backend
 npm run build:frontend
-npm run deploy:backend
+npm run deploy:backend  # wrangler deploy --env production を実行
 
-# 各ディレクトリから
-cd apps/backend && npm run deploy
+# 各ディレクトリから（本番デプロイは必ず --env production を使用）
+cd apps/backend && npm run deploy  # = wrangler deploy --env production
 cd apps/frontend && npm run deploy
 ```
+
+> ⚠️ **注意**: Backend のデプロイは必ず `--env production` を使用してください。
+> 誤って開発用D1（`gh-trends-db-dev`）に本番データが混入するリスクを防ぎます。
 
 ### データベース操作
 
@@ -54,15 +57,28 @@ cd apps/backend
 # WranglerからTypeScript型を生成
 npm run cf-typegen
 
-# データベーススキーマを適用（リモートD1）
+# 開発用D1の初回セットアップ（初回のみ実行）
+# 出力された database_id を wrangler.jsonc の env.development に記入すること
+npx wrangler d1 create gh-trends-db-dev
+
+# スキーマ適用（開発用D1）
+npx wrangler d1 execute gh-trends-db-dev --file=schema/schema.sql --remote
+
+# スキーマ適用（本番D1）
 npx wrangler d1 execute gh-trends-db --file=schema/schema.sql --remote
 
-# データベースを直接クエリ
+# 開発用D1を直接クエリ
+npx wrangler d1 execute gh-trends-db-dev --command="SELECT * FROM repositories LIMIT 10" --remote
+
+# 本番D1を直接クエリ（⚠️ 誤操作注意）
 npx wrangler d1 execute gh-trends-db --command="SELECT * FROM repositories LIMIT 10" --remote
 
-# ローカル開発用データベース
-npx wrangler d1 execute gh-trends-db --file=schema/schema.sql --local
+# ローカル開発用データベース（--local フラグはローカルSQLiteを使用）
+npx wrangler d1 execute gh-trends-db-dev --file=schema/schema.sql --local
 ```
+
+> ⚠️ **注意**: `wrangler d1 execute --remote` は本番DBへの直接操作です。
+> 誤操作リスクが高いため、通常の開発では `--local` または開発用D1（`gh-trends-db-dev`）を使用してください。
 
 ### その他の便利コマンド
 
@@ -215,19 +231,39 @@ export interface NewResponse {
 | ---------------- | ------------ | ---------------------- |
 | `DB`             | `D1Database` | Cloudflare D1データベース |
 
-設定場所: `apps/backend/wrangler.jsonc`
+設定場所: `apps/backend/wrangler.jsonc`（環境別に分離）
 
 ```jsonc
 {
-  "d1_databases": [
-    {
-      "binding": "DB",
-      "database_name": "gh-trends-db",
-      "database_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  "env": {
+    "development": {
+      "d1_databases": [
+        {
+          "binding": "DB",
+          "database_name": "gh-trends-db-dev",
+          "database_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"  // 開発用D1
+        }
+      ]
+    },
+    "production": {
+      "d1_databases": [
+        {
+          "binding": "DB",
+          "database_name": "gh-trends-db",
+          "database_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"  // 本番D1
+        }
+      ]
     }
-  ]
+  }
 }
 ```
+
+**環境別コマンド:**
+
+| 用途 | コマンド |
+| ---- | -------- |
+| 開発サーバー起動 | `npm run dev` (= `wrangler dev --env development`) |
+| 本番デプロイ | `npm run deploy` (= `wrangler deploy --env production`) |
 
 ### 環境変数
 
@@ -305,9 +341,13 @@ tsconfig.base.json (共通設定)
 
 ### データベースID管理
 
-`wrangler.jsonc`のD1データベースIDは**環境固有**です。
+`wrangler.jsonc` の D1 データベース ID は**環境固有**であり、`env.development` と `env.production` に分けて直接記述します（環境変数管理はしません）。
 
-新しいデータベースを作成する場合を除き、このIDの変更をコミットしないでください。
+- **開発用** (`env.development`): `gh-trends-db-dev` の database_id
+- **本番用** (`env.production`): `gh-trends-db` の database_id
+
+開発用D1を新規作成した場合は `wrangler.jsonc` の `env.development.d1_databases[0].database_id` を更新してコミットしてください。
+本番 database_id は変更不要です（変更する場合のみコミット）。
 
 ### CORS設定
 


### PR DESCRIPTION
## Summary

- `wrangler.jsonc` のトップレベル D1 バインディングを廃止し `env.development` / `env.production` に分離
- 開発環境（`gh-trends-db-dev`）と本番環境（`gh-trends-db`）のDB向き先を明示分離
- Cron Triggers を `env.production` のみに設定（開発環境では不要）
- `apps/backend/package.json` の `dev`/`start` スクリプトに `--env development`、`deploy` に `--env production` を追加
- 開発ガイドに環境別コマンド・DB操作手順・ID管理方針を反映

## Test plan

- [ ] `npm run dev:backend` が `wrangler dev --env development` で起動することを確認
- [ ] `npm run deploy:backend` が `wrangler deploy --env production` で実行されることを確認
- [ ] `npx wrangler d1 create gh-trends-db-dev` を実行し、`wrangler.jsonc` の `env.development.d1_databases[0].database_id` に記入して動作確認
- [ ] `wrangler d1 execute gh-trends-db-dev --command "SELECT 1" --remote` が通ることを確認

## Changes

| ファイル | 変更内容 |
|----------|----------|
| `apps/backend/wrangler.jsonc` | top-level D1 バインディング廃止 → `env.development`/`env.production` に分離、Cron Triggers を production のみに移動 |
| `apps/backend/package.json` | `dev`/`start` に `--env development`、`deploy` に `--env production` を追加 |
| `docs/基本/開発ガイド.md` | 環境別コマンド表・DB初回セットアップ手順・バインディング設定例・ID管理方針を更新 |

## 初回セットアップ手順（マージ後に必要）

```bash
cd apps/backend
npx wrangler d1 create gh-trends-db-dev
# 出力された database_id を wrangler.jsonc の env.development.d1_databases[0].database_id に記入してコミット
```

Closes #150