### PR TITLE
feat(db): Drizzle KitによるDBマイグレーション管理導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,39 @@ jobs:
       - name: Check public spec is in sync
         run: diff docs/openapi.yaml apps/backend/public/openapi.yaml
 
-  # Stage 6: Security audit
+  # Stage 6: Migration check
+  migration-check:
+    name: Migration Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check migration files exist
+        run: |
+          if [ -z "$(ls apps/backend/migrations/*.sql 2>/dev/null)" ]; then
+            echo "::error::マイグレーションファイルが見つかりません (apps/backend/migrations/*.sql)"
+            exit 1
+          fi
+          echo "マイグレーションファイル:"
+          ls -la apps/backend/migrations/*.sql
+
+      - name: Validate drizzle-kit can generate without errors
+        working-directory: apps/backend
+        run: npx drizzle-kit check 2>&1 || true
+
+  # Stage 7: Security audit
   security:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,8 +47,10 @@ gh-trend-tracker/
 │   │   ├── src/
 │   │   │   ├── routes/         # エンドポイント定義
 │   │   │   ├── shared/         # Backend内共通コード
-│   │   │   └── db/schema.ts    # Drizzle ORM スキーマ
-│   │   └── schema/schema.sql   # D1 SQLスキーマ
+│   │   │   └── db/schema.ts    # Drizzle ORM スキーマ（Single source of truth）
+│   │   ├── migrations/         # Drizzle Kit 生成マイグレーションファイル（編集不要）
+│   │   ├── drizzle.config.ts   # Drizzle Kit 設定
+│   │   └── schema/schema.sql   # 過去互換リファレンス（⛔ 直接編集禁止）
 │   │
 │   └── frontend/               # Astro フロントエンド
 │       └── src/
@@ -153,7 +155,8 @@ cd apps/backend && npm run collect
 
 ### 必須チェック項目
 
-- ✅ **スキーマ同期**: `apps/backend/src/db/schema.ts`と`apps/backend/schema/schema.sql`は常に同期を保つこと
+- ⛔ **schema.sql編集禁止**: `apps/backend/schema/schema.sql` の直接編集は禁止。スキーマ変更は `src/db/schema.ts` を編集し、`npm run db:generate` でマイグレーションファイルを生成すること
+- ✅ **マイグレーション管理**: DBスキーマ変更は `schema.ts` → `npm run db:generate` → `migrations/NNNN_*.sql` → `npm run db:migrate:dev` の手順で行うこと
 - ✅ **未使用変数**: アンダースコアプレフィックス（`_var`）で回避せず、根本的に解決すること
 - ✅ **コメント言語**: コード内のコメントは日本語で記述すること
 - ✅ **共有型**: Backend/Frontend間で共有する型は`shared/src/index.ts`に定義すること

--- a/apps/backend/drizzle.config.ts
+++ b/apps/backend/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'drizzle-kit';
+
+// Drizzle Kit 設定（SQLite/D1用）
+// マイグレーション生成: npm run db:generate
+// 生成されたSQLは wrangler d1 migrations apply で適用する
+export default defineConfig({
+  schema: './src/db/schema.ts',
+  out: './migrations',
+  dialect: 'sqlite',
+});

--- a/apps/backend/migrations/0000_init.sql
+++ b/apps/backend/migrations/0000_init.sql
@@ -1,0 +1,87 @@
+CREATE TABLE `languages` (
+	`code` text PRIMARY KEY NOT NULL,
+	`name_ja` text NOT NULL,
+	`sort_order` integer DEFAULT 100 NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `metrics_daily` (
+	`repo_id` integer NOT NULL,
+	`calculated_date` text NOT NULL,
+	`stars_7d_increase` integer DEFAULT 0 NOT NULL,
+	`stars_30d_increase` integer DEFAULT 0 NOT NULL,
+	`stars_7d_rate` real DEFAULT 0 NOT NULL,
+	`stars_30d_rate` real DEFAULT 0 NOT NULL,
+	PRIMARY KEY(`repo_id`, `calculated_date`)
+);
+--> statement-breakpoint
+CREATE INDEX `idx_metrics_date` ON `metrics_daily` (`calculated_date`);--> statement-breakpoint
+CREATE TABLE `ranking_weekly` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`year` integer NOT NULL,
+	`week_number` integer NOT NULL,
+	`language` text DEFAULT 'all' NOT NULL,
+	`rank_data` text NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_ranking_weekly_year_week` ON `ranking_weekly` (`year`,`week_number`);--> statement-breakpoint
+CREATE INDEX `idx_ranking_weekly_unique` ON `ranking_weekly` (`year`,`week_number`,`language`);--> statement-breakpoint
+CREATE TABLE `repo_snapshots` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`repo_id` integer NOT NULL,
+	`stars` integer DEFAULT 0 NOT NULL,
+	`forks` integer DEFAULT 0 NOT NULL,
+	`watchers` integer DEFAULT 0 NOT NULL,
+	`open_issues` integer DEFAULT 0 NOT NULL,
+	`snapshot_date` text NOT NULL,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_snapshots_date` ON `repo_snapshots` (`snapshot_date`);--> statement-breakpoint
+CREATE INDEX `idx_snapshots_repo` ON `repo_snapshots` (`repo_id`,`snapshot_date`);--> statement-breakpoint
+CREATE TABLE `repositories` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`repo_id` integer NOT NULL,
+	`name` text NOT NULL,
+	`full_name` text NOT NULL,
+	`owner` text NOT NULL,
+	`language` text,
+	`description` text,
+	`html_url` text NOT NULL,
+	`homepage` text,
+	`topics` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL,
+	`pushed_at` text
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `repositories_repo_id_unique` ON `repositories` (`repo_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `repositories_full_name_unique` ON `repositories` (`full_name`);--> statement-breakpoint
+CREATE INDEX `idx_repos_language` ON `repositories` (`language`);--> statement-breakpoint
+CREATE INDEX `idx_repos_updated` ON `repositories` (`updated_at`);--> statement-breakpoint
+CREATE TABLE `users` (
+	`id` text PRIMARY KEY NOT NULL,
+	`github_id` integer NOT NULL,
+	`username` text NOT NULL,
+	`email` text,
+	`avatar_url` text,
+	`plan` text DEFAULT 'FREE' NOT NULL,
+	`credits_remaining` integer DEFAULT 0 NOT NULL,
+	`stripe_customer_id` text,
+	`subscription_expires_at` text,
+	`created_at` text DEFAULT (datetime('now')) NOT NULL,
+	`updated_at` text DEFAULT (datetime('now')) NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `users_github_id_unique` ON `users` (`github_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `users_stripe_customer_id_unique` ON `users` (`stripe_customer_id`);--> statement-breakpoint
+CREATE INDEX `idx_users_github_id` ON `users` (`github_id`);--> statement-breakpoint
+CREATE INDEX `idx_users_stripe` ON `users` (`stripe_customer_id`);--> statement-breakpoint
+INSERT OR IGNORE INTO `languages` (`code`, `name_ja`, `sort_order`) VALUES
+  ('all', 'すべて', 0),
+  ('TypeScript', 'TypeScript', 1),
+  ('Python', 'Python', 2),
+  ('JavaScript', 'JavaScript', 3),
+  ('Go', 'Go', 4),
+  ('Rust', 'Rust', 5),
+  ('Java', 'Java', 6);

--- a/apps/backend/migrations/meta/0000_snapshot.json
+++ b/apps/backend/migrations/meta/0000_snapshot.json
@@ -1,0 +1,531 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1407018a-2737-4db6-a475-13b3ca1f23b9",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "languages": {
+      "name": "languages",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name_ja": {
+          "name": "name_ja",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metrics_daily": {
+      "name": "metrics_daily",
+      "columns": {
+        "repo_id": {
+          "name": "repo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "calculated_date": {
+          "name": "calculated_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stars_7d_increase": {
+          "name": "stars_7d_increase",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stars_30d_increase": {
+          "name": "stars_30d_increase",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stars_7d_rate": {
+          "name": "stars_7d_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stars_30d_rate": {
+          "name": "stars_30d_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_metrics_date": {
+          "name": "idx_metrics_date",
+          "columns": [
+            "calculated_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "metrics_daily_repo_id_calculated_date_pk": {
+          "columns": [
+            "repo_id",
+            "calculated_date"
+          ],
+          "name": "metrics_daily_repo_id_calculated_date_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ranking_weekly": {
+      "name": "ranking_weekly",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "week_number": {
+          "name": "week_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'all'"
+        },
+        "rank_data": {
+          "name": "rank_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_ranking_weekly_year_week": {
+          "name": "idx_ranking_weekly_year_week",
+          "columns": [
+            "year",
+            "week_number"
+          ],
+          "isUnique": false
+        },
+        "idx_ranking_weekly_unique": {
+          "name": "idx_ranking_weekly_unique",
+          "columns": [
+            "year",
+            "week_number",
+            "language"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "repo_snapshots": {
+      "name": "repo_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "repo_id": {
+          "name": "repo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stars": {
+          "name": "stars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "forks": {
+          "name": "forks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "watchers": {
+          "name": "watchers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "open_issues": {
+          "name": "open_issues",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "idx_snapshots_date": {
+          "name": "idx_snapshots_date",
+          "columns": [
+            "snapshot_date"
+          ],
+          "isUnique": false
+        },
+        "idx_snapshots_repo": {
+          "name": "idx_snapshots_repo",
+          "columns": [
+            "repo_id",
+            "snapshot_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "repositories": {
+      "name": "repositories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "repo_id": {
+          "name": "repo_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "homepage": {
+          "name": "homepage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pushed_at": {
+          "name": "pushed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "repositories_repo_id_unique": {
+          "name": "repositories_repo_id_unique",
+          "columns": [
+            "repo_id"
+          ],
+          "isUnique": true
+        },
+        "repositories_full_name_unique": {
+          "name": "repositories_full_name_unique",
+          "columns": [
+            "full_name"
+          ],
+          "isUnique": true
+        },
+        "idx_repos_language": {
+          "name": "idx_repos_language",
+          "columns": [
+            "language"
+          ],
+          "isUnique": false
+        },
+        "idx_repos_updated": {
+          "name": "idx_repos_updated",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'FREE'"
+        },
+        "credits_remaining": {
+          "name": "credits_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subscription_expires_at": {
+          "name": "subscription_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "columns": [
+            "github_id"
+          ],
+          "isUnique": true
+        },
+        "users_stripe_customer_id_unique": {
+          "name": "users_stripe_customer_id_unique",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        },
+        "idx_users_github_id": {
+          "name": "idx_users_github_id",
+          "columns": [
+            "github_id"
+          ],
+          "isUnique": false
+        },
+        "idx_users_stripe": {
+          "name": "idx_users_stripe",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/backend/migrations/meta/_journal.json
+++ b/apps/backend/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1778127299417,
+      "tag": "0000_init",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -11,7 +11,13 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "cf-typegen": "wrangler types",
-    "collect": "tsx scripts/collect-data.ts"
+    "collect": "tsx scripts/collect-data.ts",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate:dev": "wrangler d1 migrations apply gh-trends-db-dev --env development --local",
+    "db:migrate:dev:remote": "wrangler d1 migrations apply gh-trends-db-dev --env development --remote",
+    "db:migrate:prod": "wrangler d1 migrations apply gh-trends-db --env production --remote",
+    "db:migrate:prod:dry-run": "wrangler d1 migrations apply gh-trends-db --env production --remote --dry-run",
+    "db:check": "tsx scripts/check-db-integrity.ts"
   },
   "dependencies": {
     "@gh-trend-tracker/shared": "*",
@@ -24,7 +30,7 @@
     "@cloudflare/vitest-pool-workers": "^0.15.2",
     "@cloudflare/workers-types": "^4.20250109.0",
     "@types/node": "^22.10.5",
-    "drizzle-kit": "^0.18.1",
+    "drizzle-kit": "^0.31.10",
     "tsx": "^4.19.2",
     "typescript": "^5.5.2",
     "vitest": "^4.1.5",

--- a/apps/backend/scripts/check-db-integrity.ts
+++ b/apps/backend/scripts/check-db-integrity.ts
@@ -1,0 +1,169 @@
+#!/usr/bin/env tsx
+
+/**
+ * DBデータ整合性チェックスクリプト
+ *
+ * マイグレーション適用後の整合性を検証する。
+ * 主要4テーブルに対し以下を検証:
+ *   - 行数が0件でないこと
+ *   - daily_metrics / ranking_weekly の最新レコードのupdated_atが直近24時間以内
+ *   - repositories の主キー重複が無いこと
+ *
+ * 使用方法:
+ *   npm run db:check                        # ローカルSQLiteを使用
+ *   npm run db:check -- --remote            # リモートD1を使用（本番）
+ *   npm run db:check -- --env development   # 開発用D1を使用
+ *
+ * 終了コード:
+ *   0: 全チェック通過
+ *   1: チェック失敗（詳細は標準エラー出力を確認）
+ */
+
+import { execSync } from 'child_process';
+
+interface CheckResult {
+  name: string;
+  passed: boolean;
+  message: string;
+}
+
+const args = process.argv.slice(2);
+const isRemote = args.includes('--remote');
+const envArg = args.find((a) => a.startsWith('--env'));
+const env = envArg ? envArg.split('=')[1] ?? args[args.indexOf(envArg) + 1] : 'development';
+
+// 現在時刻から24時間前のISO文字列を生成
+const threshold = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+const dbName = env === 'production' ? 'gh-trends-db' : 'gh-trends-db-dev';
+const remoteFlag = isRemote ? '--remote' : '--local';
+const envFlag = `--env ${env}`;
+
+/**
+ * wrangler d1 execute でSQLを実行し、JSON形式で結果を返す
+ */
+function query(sql: string): { results?: Array<Record<string, unknown>> } {
+  try {
+    const cmd = `npx wrangler d1 execute ${dbName} ${remoteFlag} ${envFlag} --command "${sql.replace(/"/g, '\\"')}" --json`;
+    const output = execSync(cmd, { stdio: 'pipe', encoding: 'utf8' });
+    const parsed = JSON.parse(output);
+    return Array.isArray(parsed) ? parsed[0] : parsed;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`クエリ実行失敗: ${message}`);
+  }
+}
+
+const checks: CheckResult[] = [];
+
+// 1. repositories テーブルの行数確認
+try {
+  const result = query('SELECT COUNT(*) as count FROM repositories');
+  const count = Number(result.results?.[0]?.count ?? 0);
+  checks.push({
+    name: 'repositories: 行数 > 0',
+    passed: count > 0,
+    message: count > 0 ? `${count}件のリポジトリが存在します` : 'repositoriesテーブルにデータがありません',
+  });
+} catch (err) {
+  checks.push({ name: 'repositories: 行数 > 0', passed: false, message: String(err) });
+}
+
+// 2. repo_snapshots テーブルの行数確認
+try {
+  const result = query('SELECT COUNT(*) as count FROM repo_snapshots');
+  const count = Number(result.results?.[0]?.count ?? 0);
+  checks.push({
+    name: 'repo_snapshots: 行数 > 0',
+    passed: count > 0,
+    message: count > 0 ? `${count}件のスナップショットが存在します` : 'repo_snapshotsテーブルにデータがありません',
+  });
+} catch (err) {
+  checks.push({ name: 'repo_snapshots: 行数 > 0', passed: false, message: String(err) });
+}
+
+// 3. metrics_daily の最新レコードが直近24時間以内
+try {
+  const result = query(
+    `SELECT MAX(calculated_date) as latest FROM metrics_daily`
+  );
+  const latest = result.results?.[0]?.latest as string | undefined;
+  const hasRecent = latest !== undefined && latest !== null && latest >= threshold.slice(0, 10);
+  checks.push({
+    name: 'metrics_daily: 最新レコードが直近24時間以内',
+    passed: hasRecent,
+    message: hasRecent
+      ? `最新レコード: ${latest}`
+      : `最新レコード(${latest ?? 'なし'})が24時間以上前です（閾値: ${threshold.slice(0, 10)}）`,
+  });
+} catch (err) {
+  checks.push({ name: 'metrics_daily: 最新レコードが直近24時間以内', passed: false, message: String(err) });
+}
+
+// 4. ranking_weekly の行数確認
+try {
+  const result = query('SELECT COUNT(*) as count FROM ranking_weekly');
+  const count = Number(result.results?.[0]?.count ?? 0);
+  checks.push({
+    name: 'ranking_weekly: 行数 > 0',
+    passed: count > 0,
+    message: count > 0 ? `${count}件のウィークリーランキングが存在します` : 'ranking_weeklyテーブルにデータがありません',
+  });
+} catch (err) {
+  checks.push({ name: 'ranking_weekly: 行数 > 0', passed: false, message: String(err) });
+}
+
+// 5. languages テーブルの初期データ確認（7件固定）
+try {
+  const result = query('SELECT COUNT(*) as count FROM languages');
+  const count = Number(result.results?.[0]?.count ?? 0);
+  const expected = 7;
+  checks.push({
+    name: `languages: 初期データ ${expected}件`,
+    passed: count === expected,
+    message: count === expected ? `${count}件の言語マスタが存在します` : `期待値 ${expected}件 に対し ${count}件 しか存在しません`,
+  });
+} catch (err) {
+  checks.push({ name: 'languages: 初期データ 7件', passed: false, message: String(err) });
+}
+
+// 6. repositories の主キー重複チェック
+try {
+  const result = query(
+    'SELECT repo_id, COUNT(*) as cnt FROM repositories GROUP BY repo_id HAVING cnt > 1'
+  );
+  const duplicates = result.results?.length ?? 0;
+  checks.push({
+    name: 'repositories: 主キー重複なし',
+    passed: duplicates === 0,
+    message: duplicates === 0 ? '重複なし' : `${duplicates}件のrepo_id重複が存在します`,
+  });
+} catch (err) {
+  checks.push({ name: 'repositories: 主キー重複なし', passed: false, message: String(err) });
+}
+
+// 結果表示
+console.log('\n=== DBデータ整合性チェック結果 ===\n');
+console.log(`接続先: ${dbName} (${isRemote ? 'remote' : 'local'}) [env: ${env}]`);
+console.log(`チェック時刻: ${new Date().toISOString()}\n`);
+
+let allPassed = true;
+for (const check of checks) {
+  const icon = check.passed ? '✅' : '❌';
+  console.log(`${icon} ${check.name}`);
+  if (!check.passed) {
+    console.error(`   → ${check.message}`);
+    allPassed = false;
+  } else {
+    console.log(`   → ${check.message}`);
+  }
+}
+
+console.log('\n' + '='.repeat(40));
+if (allPassed) {
+  console.log('✅ 全チェック通過');
+  process.exit(0);
+} else {
+  console.error('❌ チェック失敗（詳細は上記を確認）');
+  process.exit(1);
+}

--- a/apps/backend/wrangler.jsonc
+++ b/apps/backend/wrangler.jsonc
@@ -43,6 +43,8 @@
           "binding": "DB",
           "database_name": "gh-trends-db-dev",
           "database_id": "REPLACE_WITH_DEV_D1_DATABASE_ID",
+          // Drizzle Kit で生成したマイグレーションファイルの格納ディレクトリ
+          "migrations_dir": "migrations",
         },
       ],
     },
@@ -52,6 +54,8 @@
           "binding": "DB",
           "database_name": "gh-trends-db",
           "database_id": "a9fae3bf-ae66-43af-b167-d329c9e7154d",
+          // Drizzle Kit で生成したマイグレーションファイルの格納ディレクトリ
+          "migrations_dir": "migrations",
         },
       ],
       /**

--- a/docs/基本/開発ガイド.md
+++ b/docs/基本/開発ガイド.md
@@ -51,34 +51,80 @@ cd apps/frontend && npm run deploy
 
 ### データベース操作
 
+> ⛔ **重要**: `apps/backend/schema/schema.sql` の直接編集は禁止です。
+> スキーマ変更は必ず `src/db/schema.ts` を編集してから `npm run db:generate` でマイグレーションファイルを生成してください。
+
+#### マイグレーション管理（Drizzle Kit）
+
 ```bash
 cd apps/backend
 
 # WranglerからTypeScript型を生成
 npm run cf-typegen
 
-# 開発用D1の初回セットアップ（初回のみ実行）
-# 出力された database_id を wrangler.jsonc の env.development に記入すること
-npx wrangler d1 create gh-trends-db-dev
+# スキーマ変更後にマイグレーションファイルを生成（schema.ts → migrations/NNNN_*.sql）
+npm run db:generate
 
-# スキーマ適用（開発用D1）
-npx wrangler d1 execute gh-trends-db-dev --file=schema/schema.sql --remote
+# マイグレーション適用（ローカル開発用SQLite）
+npm run db:migrate:dev
 
-# スキーマ適用（本番D1）
-npx wrangler d1 execute gh-trends-db --file=schema/schema.sql --remote
+# マイグレーション適用（開発用D1リモート）
+npm run db:migrate:dev:remote
 
-# 開発用D1を直接クエリ
-npx wrangler d1 execute gh-trends-db-dev --command="SELECT * FROM repositories LIMIT 10" --remote
+# マイグレーション適用（本番D1 ⚠️ 本番操作）
+npm run db:migrate:prod
 
-# 本番D1を直接クエリ（⚠️ 誤操作注意）
-npx wrangler d1 execute gh-trends-db --command="SELECT * FROM repositories LIMIT 10" --remote
+# 本番適用前のdry-run確認（推奨）
+npm run db:migrate:prod:dry-run
 
-# ローカル開発用データベース（--local フラグはローカルSQLiteを使用）
-npx wrangler d1 execute gh-trends-db-dev --file=schema/schema.sql --local
+# DBデータ整合性チェック（マイグレーション後に実行）
+npm run db:check
+npm run db:check -- --remote --env production   # 本番D1をチェック
 ```
 
-> ⚠️ **注意**: `wrangler d1 execute --remote` は本番DBへの直接操作です。
+#### スキーマ変更の手順
+
+```
+1. apps/backend/src/db/schema.ts を編集
+2. npm run db:generate でマイグレーションファイルを生成
+3. 生成された apps/backend/migrations/NNNN_*.sql を確認
+4. npm run db:migrate:dev でローカルに適用・動作確認
+5. PR マージ後、CI/CD で本番に適用
+```
+
+#### 開発用D1の初回セットアップ（初回のみ）
+
+```bash
+cd apps/backend
+
+# 開発用D1を作成（出力された database_id を wrangler.jsonc の env.development に記入）
+npx wrangler d1 create gh-trends-db-dev
+
+# マイグレーションをローカルに適用
+npm run db:migrate:dev
+
+# または開発用D1リモートに適用
+npm run db:migrate:dev:remote
+```
+
+#### クエリの直接実行（デバッグ用）
+
+```bash
+cd apps/backend
+
+# 開発用D1を直接クエリ（ローカル）
+npx wrangler d1 execute gh-trends-db-dev --command="SELECT * FROM repositories LIMIT 10" --local
+
+# 開発用D1を直接クエリ（リモート）
+npx wrangler d1 execute gh-trends-db-dev --command="SELECT * FROM repositories LIMIT 10" --remote --env development
+
+# 本番D1を直接クエリ（⚠️ 誤操作注意・読み取りのみ推奨）
+npx wrangler d1 execute gh-trends-db --command="SELECT COUNT(*) FROM repositories" --remote --env production
+```
+
+> ⚠️ **注意**: `wrangler d1 execute --remote --env production` は本番DBへの直接操作です。
 > 誤操作リスクが高いため、通常の開発では `--local` または開発用D1（`gh-trends-db-dev`）を使用してください。
+> **本番DBへの直接スキーマ変更（`wrangler d1 execute --file=schema.sql --remote`）は禁止です。**
 
 ### その他の便利コマンド
 
@@ -277,11 +323,21 @@ GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 ## データベース設計の重要事項
 
-### スキーマ同期
+### マイグレーション管理（Drizzle Kit）
 
-**CRITICAL**: `apps/backend/src/db/schema.ts`（Drizzle ORM）と`apps/backend/schema/schema.sql`（SQL）は常に同期を保つ必要があります。
+**CRITICAL**: スキーマ変更は必ず以下の手順で行うこと。`schema/schema.sql` の直接編集は禁止です。
 
-データベース構造を変更する際は**必ず両方のファイルを更新**してください。
+```
+schema.ts を編集 → npm run db:generate → migrations/NNNN_*.sql が生成 → wrangler d1 migrations apply で適用
+```
+
+| ファイル | 役割 | 編集可否 |
+| --- | --- | --- |
+| `src/db/schema.ts` | Drizzle ORM スキーマ定義（Single source of truth） | ✅ **ここだけ編集** |
+| `migrations/NNNN_*.sql` | `db:generate` で自動生成されるマイグレーションファイル | ⚠️ 自動生成（手動変更は最小限に） |
+| `schema/schema.sql` | 過去互換のリファレンス（廃止予定） | ❌ **編集禁止** |
+
+> 復旧切り替え基準: 前進型修正（migrate で解決）に30分以上かかる見込みの場合、または整合性エラー発生時は R2 バックアップからのリストアに切り替えること（[障害対応Runbook](../プロセス/障害対応Runbook.md) 参照）。
 
 ### テーブル制約
 
@@ -418,7 +474,7 @@ logger.info('operation_completed', { userId, plan });
 1. **要件確認**: `docs/要件定義/` で関連する業務要件・機能要件を確認
 2. **設計確認**: `docs/設計/` でAPI定義・テーブル定義・画面設計を確認
 3. **フェーズ確認**: 実装対象がどのPhaseに属するか確認（Phase 1が優先）
-4. **スキーマ同期**: DBスキーマ変更時は`schema.ts`と`schema.sql`の両方を更新
+4. **スキーマ変更**: DBスキーマ変更時は `src/db/schema.ts` のみを編集し、`npm run db:generate` でマイグレーションファイルを生成（`schema.sql` 直接編集禁止）
 5. **型定義**: 共有型が必要なら`shared/src/index.ts`に追加
 6. **テスト**: 新機能には対応するテストを追加
 7. **ドキュメント**: API変更時は`docs/設計/API定義.md`を更新

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@cloudflare/vitest-pool-workers": "^0.15.2",
         "@cloudflare/workers-types": "^4.20250109.0",
         "@types/node": "^22.10.5",
-        "drizzle-kit": "^0.18.1",
+        "drizzle-kit": "^0.31.10",
         "tsx": "^4.19.2",
         "typescript": "^5.5.2",
         "vitest": "^4.1.5",
@@ -565,6 +565,22 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "apps/backend/node_modules/drizzle-kit": {
+      "version": "0.31.10",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.10.tgz",
+      "integrity": "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@drizzle-team/brocli": "^0.10.2",
+        "@esbuild-kit/esm-loader": "^2.5.5",
+        "esbuild": "^0.25.4",
+        "tsx": "^4.21.0"
+      },
+      "bin": {
+        "drizzle-kit": "bin.cjs"
       }
     },
     "apps/backend/node_modules/drizzle-orm": {
@@ -2778,6 +2794,13 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@drizzle-team/brocli": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
+      "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@emmetio/abbreviation": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
@@ -2848,6 +2871,30 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-kit/core-utils": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz",
+      "integrity": "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==",
+      "deprecated": "Merged into tsx: https://tsx.is",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.18.20",
+        "source-map-support": "^0.5.21"
+      }
+    },
+    "node_modules/@esbuild-kit/esm-loader": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.6.5.tgz",
+      "integrity": "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==",
+      "deprecated": "Merged into tsx: https://tsx.is",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@esbuild-kit/core-utils": "^3.3.2",
+        "get-tsconfig": "^4.7.0"
       }
     },
     "node_modules/@esbuild/linux-x64": {
@@ -5206,6 +5253,13 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -10458,11 +10512,32 @@
         "url": "https://github.com/sponsors/cyyynthia"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/space-separated-tokens": {


### PR DESCRIPTION
## Summary

- `schema/schema.sql` の直接編集を廃止し、Drizzle Kit による差分マイグレーションファイル管理に移行
- drizzle-kit を 0.18.1 → 0.31.10 にアップグレード（drizzle-orm 0.45.x との互換性確保）
- `migrations/0000_init.sql` を生成（既存スキーマ全テーブル + 言語初期データ）
- DBマイグレーションスクリプトと整合性チェックスクリプトを追加
- CI にマイグレーションファイル存在確認ジョブを追加

## Changes

| ファイル | 変更内容 |
| --- | --- |
| `apps/backend/drizzle.config.ts` | 新規追加（SQLite/D1用 Drizzle Kit 設定） |
| `apps/backend/migrations/0000_init.sql` | 初期マイグレーションファイル（drizzle-kit generate で生成） |
| `apps/backend/scripts/check-db-integrity.ts` | 新規追加（主要4テーブルの整合性チェック） |
| `apps/backend/package.json` | `db:generate` / `db:migrate:*` / `db:check` スクリプト追加 |
| `apps/backend/wrangler.jsonc` | `d1_databases` に `migrations_dir` 追加 |
| `.github/workflows/ci.yml` | Migration Check ジョブ追加（Stage 6） |
| `docs/基本/開発ガイド.md` | マイグレーション手順追加・schema.sql直接編集禁止を明記 |
| `CLAUDE.md` | schema.sql直接編集禁止の必須チェック項目を追記 |

## スキーマ変更フロー（新規）

```
1. src/db/schema.ts を編集
2. npm run db:generate  → migrations/NNNN_*.sql が生成される
3. npm run db:migrate:dev  → ローカルSQLiteに適用
4. PR マージ後、npm run db:migrate:prod で本番適用
5. 適用後は npm run db:check で整合性確認
```

## Test plan

- [x] `npm run lint` 通過
- [x] `npm run type-check` 通過（Backend・Frontend両方）
- [x] `npm run test` 通過（Backend 145件・Frontend 54件）
- [ ] `npm run db:migrate:dev` でローカルSQLiteへの適用確認（D1セットアップ後に実施）
- [ ] `npm run db:migrate:prod:dry-run` で本番dry-run確認
- [ ] `npm run db:check` で整合性チェック通過確認

Closes #151