### PR TITLE
perf(core): Automated performance tuning by Claude

### DIFF
--- a/apps/backend/src/services/metrics-calculator.ts
+++ b/apps/backend/src/services/metrics-calculator.ts
@@ -6,7 +6,7 @@ import type { DrizzleD1Database } from 'drizzle-orm/d1';
 import { eq } from 'drizzle-orm';
 import type { BatchMetricsResponse } from '@gh-trend-tracker/shared';
 import { getTodayISO } from '../shared/utils';
-import { repositories, repoSnapshots } from '../db/schema';
+import { repoSnapshots } from '../db/schema';
 import { calculateAndUpsertMetricsBatch } from './batch-db';
 
 export interface MetricsCalculateOptions {
@@ -28,7 +28,6 @@ export async function runMetricsCalculation(
   const todaySnaps = await db
     .select({ repoId: repoSnapshots.repoId, stars: repoSnapshots.stars })
     .from(repoSnapshots)
-    .innerJoin(repositories, eq(repoSnapshots.repoId, repositories.repoId))
     .where(eq(repoSnapshots.snapshotDate, todayDate));
 
   if (todaySnaps.length === 0) {


### PR DESCRIPTION
### Motivation
- `runMetricsCalculation` の初回クエリから不要な `INNER JOIN` を削除して、クエリ実行時の結合コスト（CPU/メモリ/レイテンシ）を低減しつつ既存の振る舞いは維持するため。

### Description
- `apps/backend/src/services/metrics-calculator.ts` で `repositories` の import と `.innerJoin(repositories, ...)` を削除し、`repo_snapshots` 単体から `repoId` と `stars` を取得するように変更しました（機能的な変更はありません）。

### Testing
- `npm run -w apps/backend test -- --run test/batch-calculate-metrics.spec.ts` — 実行結果: 12 tests passed（成功）。
- `npm run -w apps/backend test -- --run src/services/batch-db.bench.test.ts` — 実行結果: 7 tests passed（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fddaef96bc8328ba1cbc63671f9973)