### PR TITLE
feat: CI/CDデプロイワークフロー追加（Backend D1 / Frontend Pages）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # deploy.ymlからの呼び出しを許可
+  workflow_call:
 
 # Cancel in-progress runs for the same branch
 concurrency:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,84 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# 同じブランチの実行中ジョブをキャンセル
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # CI通過確認（デプロイ前提条件）
+  ci-check:
+    name: CI Check
+    uses: ./.github/workflows/ci.yml
+
+  # BackendデプロイJob: D1マイグレーション → Workersデプロイ
+  deploy-backend:
+    name: Deploy Backend
+    runs-on: ubuntu-latest
+    needs: ci-check
+    environment: production
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run D1 migrations
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: npm run db:migrate:prod
+
+      - name: Deploy to Cloudflare Workers
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: npm run deploy
+
+  # FrontendデプロイJob: Astroビルド → Cloudflare Pagesデプロイ
+  deploy-frontend:
+    name: Deploy Frontend
+    runs-on: ubuntu-latest
+    needs: ci-check
+    environment: production
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: apps/frontend
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/frontend
+        run: npx wrangler pages deploy dist --project-name=gh-trend-tracker-frontend

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "vitest run",
-    "deploy": "echo \"Deploy not yet configured\""
+    "deploy": "wrangler pages deploy dist --project-name=gh-trend-tracker-frontend"
   },
   "dependencies": {
     "@astrojs/react": "^4.4.2",

--- a/docs/プロセス/GitHubActions設定.md
+++ b/docs/プロセス/GitHubActions設定.md
@@ -280,8 +280,72 @@ GitHub Actionsのログは90日間保持されます。重要なデータは別�
 
 これで毎日自動的にGitHubトレンドデータが収集され、リモートD1データベースに保存されます。
 
-**次のステップ:**
+---
 
-1. フロントエンドをCloudflare Pagesにデプロイ
-2. リモートD1データベースに接続
-3. 本番環境でMVP完成！
+## 自動デプロイ（deploy.yml）
+
+`.github/workflows/deploy.yml` は `main` ブランチへの push 時または手動トリガーで自動デプロイを実行します。
+
+### デプロイフロー
+
+```
+main へ push
+  └─ ci-check（ci.yml の全ジョブをreuse）
+       ├─ deploy-backend（並列）
+       │    ├─ D1 マイグレーション（npm run db:migrate:prod）
+       │    └─ Cloudflare Workers デプロイ（npm run deploy）
+       └─ deploy-frontend（並列）
+            ├─ Astro ビルド（npm run build）
+            └─ Cloudflare Pages デプロイ（wrangler pages deploy）
+```
+
+### 必要なシークレット（デプロイ用）
+
+データ収集と同じシークレット（`CLOUDFLARE_API_TOKEN`、`CLOUDFLARE_ACCOUNT_ID`）を使用します。
+
+### 手動デプロイ手順（緊急時・CI迂回時）
+
+GitHub Actions を使わずに手動でデプロイする場合：
+
+```bash
+# 1. Cloudflare認証を確認
+npx wrangler whoami
+
+# 2. Backendデプロイ
+cd apps/backend
+
+# D1マイグレーションのdry-run（確認）
+npm run db:migrate:prod:dry-run
+
+# D1マイグレーション適用
+npm run db:migrate:prod
+
+# Workersデプロイ
+npm run deploy
+
+# 3. Frontendデプロイ
+cd ../frontend
+
+# ビルド
+npm run build
+
+# Cloudflare Pagesへデプロイ
+npx wrangler pages deploy dist --project-name=gh-trend-tracker-frontend
+```
+
+### Cloudflare Pagesプロジェクトの初回作成
+
+初回デプロイ前に Pages プロジェクトを作成する必要があります：
+
+```bash
+# プロジェクト作成（初回のみ）
+npx wrangler pages project create gh-trend-tracker-frontend
+```
+
+または Cloudflare ダッシュボード（https://dash.cloudflare.com）から「Workers & Pages」→「Create」で作成。
+
+### デプロイ失敗時の確認
+
+- GitHub Actions の **Actions** タブでログを確認
+- `deploy-backend` または `deploy-frontend` ジョブが赤くなっていれば失敗
+- `ci-check` が失敗している場合は lint/テスト/ビルドエラーを先に修正する


### PR DESCRIPTION
## Summary

- `main` への push 時に Backend（D1マイグレーション→Cloudflare Workers）と Frontend（Astroビルド→Cloudflare Pages）を自動デプロイするワークフロー（`deploy.yml`）を追加
- `ci.yml` に `workflow_call` トリガーを追加し、`deploy.yml` から再利用可能に（デプロイ前に全CIチェックが通過することを保証）
- `apps/frontend/package.json` の `deploy` スクリプトを実際のデプロイコマンドに更新
- 手動デプロイ手順を `docs/プロセス/GitHubActions設定.md` に追記

## デプロイフロー

```
main へ push
  └─ ci-check（ci.yml の全ジョブを再利用）
       ├─ deploy-backend（並列）
       │    ├─ D1 マイグレーション（npm run db:migrate:prod）
       │    └─ Cloudflare Workers デプロイ（npm run deploy）
       └─ deploy-frontend（並列）
            ├─ Astro ビルド（npm run build）
            └─ Cloudflare Pages デプロイ（wrangler pages deploy）
```

## 必要なGitHub Secrets

- `CLOUDFLARE_API_TOKEN` — 既存シークレット（`collect-data.yml` と共用）
- `CLOUDFLARE_ACCOUNT_ID` — 既存シークレット（`collect-data.yml` と共用）

## Test plan

- [ ] `CLOUDFLARE_API_TOKEN` と `CLOUDFLARE_ACCOUNT_ID` がリポジトリのSecretsに設定されていることを確認
- [ ] Cloudflare Pages プロジェクト `gh-trend-tracker-frontend` が作成済みであることを確認（初回のみ `wrangler pages project create` が必要）
- [ ] `workflow_dispatch` で `deploy.yml` を手動実行し、Backend/Frontend デプロイが成功することを確認
- [ ] デプロイ失敗時に Actions が赤くなることを確認

Closes #135