### PR TITLE
docs: package.json overrides の根拠・解除条件を開発ガイドに文書化

### DIFF
--- a/docs/基本/開発ガイド.md
+++ b/docs/基本/開発ガイド.md
@@ -481,6 +481,41 @@ logger.info('operation_completed', { userId, plan });
 
 詳細は [開発プロセス](../プロセス/開発プロセス.md) を参照してください。
 
+## 依存 overrides 一覧
+
+`package.json` の `overrides` フィールドに設定された依存バージョン強制の根拠・解除条件を管理するセクションです。
+JSON にコメントを書けないため、変更理由はここに記録します。
+
+> ⚠️ **棚卸し推奨サイクル**: 半年に1回（1月・7月を目安）、下記の解除条件を確認して不要な override を削除してください。
+
+| パッケージ | 強制バージョン | 理由 | 解除条件 |
+| --- | --- | --- | --- |
+| `@types/react` | `^18.3.27` | recharts が React 18 の型定義と互換性問題を起こすため React 18 型に固定（[commit ea63ee3](https://github.com/hirata97/gh-trend-tracker/commit/ea63ee3)、Issue [#41](https://github.com/hirata97/gh-trend-tracker/issues/41)) | recharts が React 19 型定義に対応したバージョンをリリースした時点で削除可 |
+| `@types/react-dom` | `^18.3.7` | `@types/react` と同様に recharts との型互換性確保のため React 18 型に固定 | `@types/react` の override 解除と同時に削除可 |
+| `esbuild` | `>=0.25.0` | 旧バージョンの esbuild に高リスクの脆弱性（undici 経由）が報告されたため最小バージョンを強制（[commit 24d7793](https://github.com/hirata97/gh-trend-tracker/commit/24d7793)） | wrangler / @cloudflare/vitest-pool-workers が esbuild >=0.25.0 を直接依存するようになった時点で削除可 |
+| `@esbuild-kit/core-utils` > `esbuild` | `>=0.25.0` | `@esbuild-kit/core-utils` が古い esbuild を引き込むため、ネストされた override で同様に最小バージョンを強制 | `@esbuild-kit/core-utils` 自体が esbuild >=0.25.0 を要求するようになった時点で削除可 |
+| `yaml` | `^2.8.4` | yaml パッケージの旧バージョンに既知の脆弱性があるため最小バージョンを強制（[commit 27b63d5](https://github.com/hirata97/gh-trend-tracker/commit/27b63d5)） | 依存ツール（yaml-language-server 等）が yaml ^2.8.4 以上を直接要求するようになった時点で削除可 |
+| `yaml-language-server` > `yaml` | `^2.8.4` | `yaml-language-server` が古い yaml を引き込むため、ネストされた override で同様に最小バージョンを強制 | `yaml-language-server` 自体が yaml ^2.8.4 以上を要求するようになった時点で削除可 |
+
+### 棚卸し手順
+
+```bash
+# 1. 現在の依存ツリーで override 対象パッケージのバージョンを確認
+npm ls esbuild
+npm ls yaml
+npm ls @types/react
+
+# 2. 上記テーブルの「解除条件」を満たしているか確認
+
+# 3. 解除条件を満たす場合は package.json の overrides から該当エントリを削除
+
+# 4. 削除後に動作確認
+npm install
+npm run type-check
+npm run test:backend
+npm run build
+```
+
 ## 将来拡張: Turborepo導入判断基準
 
 現時点ではTurborepoを導入せず、npm workspacesのみで運用する。


### PR DESCRIPTION
## Summary

- `docs/基本/開発ガイド.md` に「依存 overrides 一覧」セクションを新設
- `package.json` の `overrides` 全6エントリについて、理由と解除条件を表形式で記録
- JSON にコメントが書けないため、ドキュメントで管理する方針を実装
- 半年に1回（1月・7月目安）の棚卸し推奨サイクルと手順コマンドを追加

## Changes

| パッケージ | 記録した理由 |
| --- | --- |
| `@types/react` / `@types/react-dom` | recharts と React 18/19 型互換性問題の回避（Issue #41） |
| `esbuild` / `@esbuild-kit/core-utils > esbuild` | 高リスク脆弱性（undici 経由）の解消（commit 24d7793） |
| `yaml` / `yaml-language-server > yaml` | yaml 旧バージョンの既知脆弱性への対応（commit 27b63d5） |

## Test plan

- [ ] `docs/基本/開発ガイド.md` の「依存 overrides 一覧」セクションが正しく表示される
- [ ] 全 override エントリに理由・解除条件が記載されている
- [ ] 棚卸し手順のコマンドが実行可能である（`npm ls esbuild` 等）

Closes #137