### PR TITLE
feat: 参照系APIのキャッシュポリシー策定と適用 (#140)

### DIFF
--- a/apps/backend/src/routes/languages.ts
+++ b/apps/backend/src/routes/languages.ts
@@ -2,12 +2,15 @@ import { Hono } from 'hono';
 import { getAllLanguages } from '../shared/queries';
 import { dbError } from '../shared/errors';
 import { logger } from '../utils/logger';
+import { cacheMiddleware } from '../middleware/cache';
 import type { LanguagesResponse, ApiError } from '@gh-trend-tracker/shared';
 import type { AppEnv } from '../types/app';
 
 const languages = new Hono<AppEnv>();
 
-// 言語一覧
+// 言語一覧（5分キャッシュ、10分stale-while-revalidate）
+languages.use('/', cacheMiddleware(300, 600));
+
 languages.get('/', async (c) => {
   const db = c.get('db');
 

--- a/apps/backend/src/routes/repositories-search.ts
+++ b/apps/backend/src/routes/repositories-search.ts
@@ -5,10 +5,14 @@ import { repositories, repoSnapshots } from '../db/schema';
 import { SearchQuerySchema } from '../schemas/search';
 import { validationError, dbError } from '../shared/errors';
 import { getTodayISO } from '../shared/utils';
+import { cacheMiddleware } from '../middleware/cache';
 import type { SearchResponse, ApiError } from '@gh-trend-tracker/shared';
 import type { AppEnv } from '../types/app';
 
 const repositoriesSearch = new Hono<AppEnv>();
+
+// 検索結果は同一クエリの重複リクエスト緩和のため1分キャッシュ、2分stale-while-revalidate
+repositoriesSearch.use('/', cacheMiddleware(60, 120));
 
 repositoriesSearch.get('/', async (c) => {
   const db = c.get('db');

--- a/apps/backend/src/routes/trends-weekly-available.ts
+++ b/apps/backend/src/routes/trends-weekly-available.ts
@@ -3,10 +3,14 @@ import { logger } from '../utils/logger';
 import { sql } from 'drizzle-orm';
 import { rankingWeekly } from '../db/schema';
 import { dbError } from '../shared/errors';
+import { cacheMiddleware } from '../middleware/cache';
 import type { AvailableWeeksResponse, ApiError, AvailableWeek } from '@gh-trend-tracker/shared';
 import type { AppEnv } from '../types/app';
 
 const trendsWeeklyAvailable = new Hono<AppEnv>();
+
+// 利用可能週リストは週1回更新のため1時間キャッシュ、24時間stale-while-revalidate
+trendsWeeklyAvailable.use('/', cacheMiddleware(3600, 86400));
 
 trendsWeeklyAvailable.get('/', async (c) => {
   const db = c.get('db');

--- a/apps/backend/src/routes/trends-weekly.ts
+++ b/apps/backend/src/routes/trends-weekly.ts
@@ -4,10 +4,14 @@ import { eq, and } from 'drizzle-orm';
 import { rankingWeekly } from '../db/schema';
 import { WeeklyTrendsQuerySchema } from '../schemas/weekly';
 import { validationError, notFoundError, dbError } from '../shared/errors';
+import { cacheMiddleware } from '../middleware/cache';
 import type { WeeklyTrendResponse, ApiError, WeeklyTrendItem } from '@gh-trend-tracker/shared';
 import type { AppEnv } from '../types/app';
 
 const trendsWeekly = new Hono<AppEnv>();
+
+// 週次データは一度計算されたら不変のため1時間キャッシュ、24時間stale-while-revalidate
+trendsWeekly.use('/', cacheMiddleware(3600, 86400));
 
 trendsWeekly.get('/', async (c) => {
   const db = c.get('db');

--- a/docs/設計/キャッシュポリシー.md
+++ b/docs/設計/キャッシュポリシー.md
@@ -1,0 +1,53 @@
+# キャッシュポリシー一覧
+
+参照系APIのキャッシュ設定（`Cache-Control: public, max-age=<TTL>, stale-while-revalidate=<SWR>`）を定義するドキュメントです。
+
+## ポリシー一覧
+
+| エンドポイント | TTL（秒） | SWR（秒） | 無効化トリガ | 理由 |
+|---|---|---|---|---|
+| `GET /api/trends/daily` | 60 | 300 | バッチ: `calculate-metrics` 完了時 | 日次計算結果。1分で即応性とDB負荷のバランスを取る |
+| `GET /api/repositories/:repoId` | 300 | 600 | バッチ: `collect-daily` 完了時 | リポジトリ詳細は1日1回更新。5分キャッシュで十分 |
+| `GET /api/repositories/:repoId/history` | 300 | 600 | バッチ: `collect-daily` 完了時 | 履歴データは1日1回追加。5分キャッシュで十分 |
+| `GET /api/languages` | 300 | 600 | バッチ: `collect-daily` 完了時 | 言語一覧は新リポジトリ追加時のみ変化。5分キャッシュ |
+| `GET /api/trends/weekly` | 3600 | 86400 | バッチ: `calculate-weekly` 完了時 | 週次データは一度計算されたら不変。1時間キャッシュ |
+| `GET /api/trends/weekly/available` | 3600 | 86400 | バッチ: `calculate-weekly` 完了時 | 利用可能週リストは週1回更新。1時間キャッシュ |
+| `GET /api/repositories/search` | 60 | 120 | なし（ユーザー入力依存） | 検索結果はクエリ依存。短めのTTLで即応性を確保 |
+
+## キャッシュ方式
+
+- **実装**: `apps/backend/src/middleware/cache.ts` の `cacheMiddleware(maxAge, swr)`
+- **対象**: 成功レスポンス（2xx）のみにキャッシュヘッダーを付与
+- **ヘッダー**:
+  - `Cache-Control: public, max-age=<TTL>, stale-while-revalidate=<SWR>` — ブラウザ・CDN共通
+  - `CDN-Cache-Control: public, max-age=<TTL>` — Cloudflare CDN向け個別指定
+
+## キャッシュ無効化（Invalidation）
+
+現時点ではキャッシュの明示的なパージ（purge）は行わず、TTL期限切れによる自然な無効化に依存します。
+
+バッチ処理（GitHub Actions）の実行間隔は最短でも1時間以上あるため、TTL範囲内で古いデータが返されても許容される設計です。
+
+将来的にリアルタイム性が必要になった場合は、Cloudflare Cache APIによるキャッシュパージを検討してください。
+
+## エンドポイント別詳細
+
+### `GET /api/trends/daily`
+- **データ更新頻度**: 1日1回（バッチ `calculate-metrics` 実行後）
+- **TTL設定理由**: 最新性とDB負荷のバランスとして1分を選択。バッチ後の最大遅延は60秒
+
+### `GET /api/repositories/:repoId` / `/:repoId/history`
+- **データ更新頻度**: 1日1回（バッチ `collect-daily` 実行後）
+- **TTL設定理由**: 詳細・履歴データはほぼ不変のため5分で十分
+
+### `GET /api/languages`
+- **データ更新頻度**: 新リポジトリ追加時のみ（実質1日1回以下）
+- **TTL設定理由**: 変化頻度が低いため5分キャッシュ。取得コストも低い
+
+### `GET /api/trends/weekly` / `available`
+- **データ更新頻度**: 週1回（バッチ `calculate-weekly` 実行後）
+- **TTL設定理由**: 週次データは一度確定したら不変のため1時間キャッシュを適用
+
+### `GET /api/repositories/search`
+- **データ更新頻度**: 逐次（ユーザー入力に依存）
+- **TTL設定理由**: 同一クエリの重複リクエストを緩和するため短い60秒を設定


### PR DESCRIPTION
## Summary

- `docs/設計/キャッシュポリシー.md` を新規作成し、全参照系エンドポイントのTTL・SWR・無効化トリガーを一覧化
- キャッシュ未適用だった4エンドポイントに `cacheMiddleware` を追加

| エンドポイント | TTL | SWR | 変更 |
|---|---|---|---|
| `GET /api/trends/daily` | 60s | 300s | 適用済み（変更なし） |
| `GET /api/repositories/:repoId` | 300s | 600s | 適用済み（変更なし） |
| `GET /api/repositories/:repoId/history` | 300s | 600s | 適用済み（変更なし） |
| `GET /api/languages` | 300s | 600s | **新規適用** |
| `GET /api/trends/weekly` | 3600s | 86400s | **新規適用** |
| `GET /api/trends/weekly/available` | 3600s | 86400s | **新規適用** |
| `GET /api/repositories/search` | 60s | 120s | **新規適用** |

## Test plan

- [x] `npm run type-check` — エラーなし
- [x] `npm run test` — 148テスト全通過
- [ ] 各エンドポイントのレスポンスヘッダーに `Cache-Control` が付与されることを確認

## Changes

- `docs/設計/キャッシュポリシー.md` — 新規作成（ポリシー一覧・各エンドポイント詳細）
- `apps/backend/src/routes/languages.ts` — `cacheMiddleware(300, 600)` を追加
- `apps/backend/src/routes/trends-weekly.ts` — `cacheMiddleware(3600, 86400)` を追加
- `apps/backend/src/routes/trends-weekly-available.ts` — `cacheMiddleware(3600, 86400)` を追加
- `apps/backend/src/routes/repositories-search.ts` — `cacheMiddleware(60, 120)` を追加

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)