### PR TITLE
feat: R2バケット作成とD1日次エクスポートcron

### DIFF
--- a/.github/workflows/backup-d1.yml
+++ b/.github/workflows/backup-d1.yml
@@ -1,0 +1,70 @@
+name: D1 Daily Backup to R2
+
+on:
+  # 毎日 UTC 02:00 に実行（日本時間 11:00 AM）
+  schedule:
+    - cron: '0 2 * * *'
+
+  # 手動実行を許可（動作確認用）
+  workflow_dispatch:
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Export D1 database to SQL
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          FILENAME="gh-trends-db_${DATE}.sql"
+          npx wrangler d1 export gh-trends-db \
+            --env production \
+            --remote \
+            --output="/tmp/${FILENAME}"
+          echo "BACKUP_FILENAME=${FILENAME}" >> "$GITHUB_ENV"
+          echo "BACKUP_DATE=${DATE}" >> "$GITHUB_ENV"
+
+      - name: Compress backup file
+        run: |
+          gzip "/tmp/${{ env.BACKUP_FILENAME }}"
+          echo "COMPRESSED_FILENAME=${{ env.BACKUP_FILENAME }}.gz" >> "$GITHUB_ENV"
+
+      - name: Upload to R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_BACKUP_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_BACKUP_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          aws s3 cp \
+            "/tmp/${{ env.COMPRESSED_FILENAME }}" \
+            "s3://gh-trends-backups/${{ env.COMPRESSED_FILENAME }}" \
+            --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+            --region auto
+
+      - name: Verify upload
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_BACKUP_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_BACKUP_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          aws s3 ls \
+            "s3://gh-trends-backups/${{ env.COMPRESSED_FILENAME }}" \
+            --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+            --region auto

--- a/docs/プロセス/GitHubActions設定.md
+++ b/docs/プロセス/GitHubActions設定.md
@@ -282,6 +282,68 @@ GitHub Actionsのログは90日間保持されます。重要なデータは別�
 
 ---
 
+## D1 日次バックアップ（backup-d1.yml）
+
+`.github/workflows/backup-d1.yml` は毎日 UTC 02:00（日本時間 11:00）に D1 データベースを R2 へエクスポートします。
+
+### バックアップフロー
+
+```
+毎日 UTC 02:00
+  └─ backup ジョブ
+       ├─ D1 export → /tmp/gh-trends-db_YYYY-MM-DD.sql
+       ├─ gzip 圧縮 → /tmp/gh-trends-db_YYYY-MM-DD.sql.gz
+       └─ R2 put → gh-trends-backups/gh-trends-db_YYYY-MM-DD.sql.gz
+```
+
+### 追加シークレットの設定
+
+バックアップ用に **最小権限の R2 API トークン** を別途作成し、2つのシークレットを追加します。
+
+#### R2 API トークンの作成
+
+1. https://dash.cloudflare.com/profile/api-tokens にアクセス
+2. **"Create Token"** → **"Create Custom Token"** を選択
+3. 以下の権限を設定：
+   - **Permissions**: `Object Storage（R2）` → `Edit`（または `Object Read & Write`）
+   - **Resources**: `Account > gh-trends-backups`（該当バケットのみ）
+4. **"Continue to summary"** → **"Create Token"** をクリック
+5. 表示された `Access Key ID` と `Secret Access Key` をコピー
+
+> **Note**: Cloudflare R2 は S3 互換 API を提供します。aws-cli を使用するため、アクセスキー形式のトークンが必要です。
+
+#### GitHub Secrets への登録
+
+| シークレット名 | 値 |
+| --- | --- |
+| `R2_BACKUP_ACCESS_KEY_ID` | R2 API トークンの Access Key ID |
+| `R2_BACKUP_SECRET_ACCESS_KEY` | R2 API トークンの Secret Access Key |
+
+> `CLOUDFLARE_ACCOUNT_ID` は既存のシークレットを流用します。
+
+### R2 バケットの作成
+
+バケット作成と90日ライフサイクルルールの設定は **Cloudflare ダッシュボード** から行います。
+
+1. https://dash.cloudflare.com → **R2 Object Storage** を開く
+2. **"Create bucket"** → バケット名: `gh-trends-backups`
+3. バケット作成後、**"Settings"** タブ → **"Object lifecycle policies"** を開く
+4. **"Add rule"** をクリックし、以下を設定：
+   - Rule name: `delete-after-90-days`
+   - Prefix: （空欄）
+   - Days until object expiration: `90`
+5. **"Save"** をクリック
+
+### 手動実行でテスト
+
+1. GitHub リポジトリの **"Actions"** タブを開く
+2. 左サイドバーの **"D1 Daily Backup to R2"** をクリック
+3. **"Run workflow"** → **"Run workflow"** をクリック
+4. 実行ログで `Upload to R2` ステップが成功することを確認
+5. Cloudflare ダッシュボードの R2 バケットに `gh-trends-db_YYYY-MM-DD.sql.gz` が存在することを確認
+
+---
+
 ## 自動デプロイ（deploy.yml）
 
 `.github/workflows/deploy.yml` は `main` ブランチへの push 時または手動トリガーで自動デプロイを実行します。


### PR DESCRIPTION
## Summary

- `.github/workflows/backup-d1.yml` を新規追加：毎日 UTC 02:00 に D1 データベースを R2 へ日次エクスポート
- D1 export → gzip 圧縮 → R2 put の3ステップで `gh-trends-db_YYYY-MM-DD.sql.gz` 形式で保存
- R2 への put は aws-cli（S3 互換エンドポイント）を使用、最小権限トークン（`R2_BACKUP_ACCESS_KEY_ID` / `R2_BACKUP_SECRET_ACCESS_KEY`）を利用
- `docs/プロセス/GitHubActions設定.md` にバケット作成・ライフサイクルルール（90日自動削除）・APIトークン登録手順を追記

## Changes

- **新規**: `.github/workflows/backup-d1.yml` — D1 daily backup to R2 workflow
- **更新**: `docs/プロセス/GitHubActions設定.md` — バックアップ用シークレット登録手順・R2バケット設定手順を追加

## Test plan

- [ ] `workflow_dispatch` で手動実行し、R2 バケット `gh-trends-backups` に `gh-trends-db_YYYY-MM-DD.sql.gz` が配置されることを確認
- [ ] Cloudflare ダッシュボードでバケットのライフサイクルルール（90日自動削除）が意図通り設定されているか確認
- [ ] GitHub Secrets に `R2_BACKUP_ACCESS_KEY_ID` と `R2_BACKUP_SECRET_ACCESS_KEY` を登録済みであることを確認
- [ ] cron 失敗時に GitHub Actions のメール通知が飛ぶことを確認（既存通知設定を流用）

## 事前作業（手動）

ワークフロー実行前に以下を手動で行う必要があります：

1. **R2 バケット作成**: Cloudflare ダッシュボード → R2 → `gh-trends-backups` バケットを作成
2. **ライフサイクルルール設定**: バケット Settings → Object lifecycle policies → 90日で自動削除
3. **R2 API トークン作成**: `gh-trends-backups` バケット限定の最小権限トークンを作成
4. **GitHub Secrets 登録**: `R2_BACKUP_ACCESS_KEY_ID` と `R2_BACKUP_SECRET_ACCESS_KEY` を登録

詳細手順は `docs/プロセス/GitHubActions設定.md` の「D1 日次バックアップ」セクションを参照。

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)