### PR TITLE
feat(#156): API互換性統合テスト追加とOpenAPI破壊的変更検知CI追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,13 +181,12 @@ jobs:
 
       - name: oasdiff をインストール
         if: steps.label-check.outputs.skip == 'false'
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/tufin/oasdiff/main/install.sh | sudo sh -s -- -b /usr/local/bin
-          oasdiff version
+        run: go install github.com/tufin/oasdiff@latest
 
       - name: ベースブランチの OpenAPI spec を取得
         if: steps.label-check.outputs.skip == 'false'
         run: |
+          git fetch origin ${{ github.base_ref }}
           git show origin/${{ github.base_ref }}:docs/openapi.yaml > /tmp/openapi-base.yaml
 
       - name: 破壊的変更を検知
@@ -196,7 +195,7 @@ jobs:
           echo "=== OpenAPI 破壊的変更チェック ==="
           echo "ベース: origin/${{ github.base_ref }}"
           echo "PR: $(git rev-parse --short HEAD)"
-          oasdiff breaking /tmp/openapi-base.yaml docs/openapi.yaml --fail-on ERR
+          $(go env GOPATH)/bin/oasdiff breaking /tmp/openapi-base.yaml docs/openapi.yaml --fail-on ERR
 
   # Stage 8: Security audit
   security:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,12 @@ jobs:
 
       - name: oasdiff をインストール
         if: steps.label-check.outputs.skip == 'false'
-        run: go install github.com/tufin/oasdiff@latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download --repo tufin/oasdiff --pattern "oasdiff_*_linux_amd64.tar.gz" --dir /tmp
+          tar -xzf /tmp/oasdiff_*_linux_amd64.tar.gz -C /usr/local/bin oasdiff
+          oasdiff version
 
       - name: ベースブランチの OpenAPI spec を取得
         if: steps.label-check.outputs.skip == 'false'
@@ -195,7 +200,7 @@ jobs:
           echo "=== OpenAPI 破壊的変更チェック ==="
           echo "ベース: origin/${{ github.base_ref }}"
           echo "PR: $(git rev-parse --short HEAD)"
-          $(go env GOPATH)/bin/oasdiff breaking /tmp/openapi-base.yaml docs/openapi.yaml --fail-on ERR
+          oasdiff breaking /tmp/openapi-base.yaml docs/openapi.yaml --fail-on ERR
 
   # Stage 8: Security audit
   security:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,48 @@ jobs:
         working-directory: apps/backend
         run: npx drizzle-kit check 2>&1 || true
 
-  # Stage 7: Security audit
+  # Stage 7: OpenAPI破壊的変更検知（PRのみ）
+  openapi-breaking-change:
+    name: OpenAPI Breaking Change Detection
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: breaking-change ラベルの確認
+        id: label-check
+        run: |
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'breaking-change') }}" == "true" ]]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "breaking-change ラベルが付与されているため、破壊的変更チェックをスキップします"
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: oasdiff をインストール
+        if: steps.label-check.outputs.skip == 'false'
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/tufin/oasdiff/main/install.sh | sudo sh -s -- -b /usr/local/bin
+          oasdiff version
+
+      - name: ベースブランチの OpenAPI spec を取得
+        if: steps.label-check.outputs.skip == 'false'
+        run: |
+          git show origin/${{ github.base_ref }}:docs/openapi.yaml > /tmp/openapi-base.yaml
+
+      - name: 破壊的変更を検知
+        if: steps.label-check.outputs.skip == 'false'
+        run: |
+          echo "=== OpenAPI 破壊的変更チェック ==="
+          echo "ベース: origin/${{ github.base_ref }}"
+          echo "PR: $(git rev-parse --short HEAD)"
+          oasdiff breaking /tmp/openapi-base.yaml docs/openapi.yaml --fail-on ERR
+
+  # Stage 8: Security audit
   security:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,42 +161,32 @@ jobs:
   openapi-breaking-change:
     name: OpenAPI Breaking Change Detection
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: >-
+      github.event_name == 'pull_request' &&
+      !contains(github.event.pull_request.labels.*.name, 'breaking-change')
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
-      - name: OpenAPI 破壊的変更を検知
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          cache: false
+
+      - name: Install oasdiff
+        run: go install github.com/tufin/oasdiff@latest
+
+      - name: Detect OpenAPI breaking changes
         env:
-          GH_TOKEN: ${{ github.token }}
-          SKIP_CHECK: ${{ contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
           BASE_REF: ${{ github.base_ref }}
         run: |
-          set -euo pipefail
-
-          if [[ "$SKIP_CHECK" == "true" ]]; then
-            echo "breaking-change ラベルが付与されているため、チェックをスキップします"
-            exit 0
-          fi
-
-          # oasdiff インストール
-          gh release download --repo tufin/oasdiff --pattern "oasdiff_*_linux_amd64.tar.gz" --dir /tmp
-          tar -xzf /tmp/oasdiff_*_linux_amd64.tar.gz -C /tmp
-          sudo install /tmp/oasdiff /usr/local/bin/oasdiff
-          oasdiff version
-
-          # ベースブランチの OpenAPI spec を取得
-          git fetch origin "$BASE_REF"
+          git fetch origin "$BASE_REF" --depth=1
           git show "origin/$BASE_REF:docs/openapi.yaml" > /tmp/openapi-base.yaml
-
-          # 破壊的変更を検知
           echo "=== OpenAPI 破壊的変更チェック ==="
           echo "ベース: origin/$BASE_REF"
-          echo "PR: $(git rev-parse --short HEAD)"
-          oasdiff breaking /tmp/openapi-base.yaml docs/openapi.yaml --fail-on ERR
+          ~/go/bin/oasdiff breaking /tmp/openapi-base.yaml docs/openapi.yaml --fail-on ERR
 
   # Stage 8: Security audit
   security:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,36 +169,32 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: breaking-change ラベルの確認
-        id: label-check
-        run: |
-          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'breaking-change') }}" == "true" ]]; then
-            echo "skip=true" >> $GITHUB_OUTPUT
-            echo "breaking-change ラベルが付与されているため、破壊的変更チェックをスキップします"
-          else
-            echo "skip=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: oasdiff をインストール
-        if: steps.label-check.outputs.skip == 'false'
+      - name: OpenAPI 破壊的変更を検知
         env:
           GH_TOKEN: ${{ github.token }}
+          SKIP_CHECK: ${{ contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
+          set -euo pipefail
+
+          if [[ "$SKIP_CHECK" == "true" ]]; then
+            echo "breaking-change ラベルが付与されているため、チェックをスキップします"
+            exit 0
+          fi
+
+          # oasdiff インストール
           gh release download --repo tufin/oasdiff --pattern "oasdiff_*_linux_amd64.tar.gz" --dir /tmp
-          tar -xzf /tmp/oasdiff_*_linux_amd64.tar.gz -C /usr/local/bin oasdiff
+          tar -xzf /tmp/oasdiff_*_linux_amd64.tar.gz -C /tmp
+          sudo install /tmp/oasdiff /usr/local/bin/oasdiff
           oasdiff version
 
-      - name: ベースブランチの OpenAPI spec を取得
-        if: steps.label-check.outputs.skip == 'false'
-        run: |
-          git fetch origin ${{ github.base_ref }}
-          git show origin/${{ github.base_ref }}:docs/openapi.yaml > /tmp/openapi-base.yaml
+          # ベースブランチの OpenAPI spec を取得
+          git fetch origin "$BASE_REF"
+          git show "origin/$BASE_REF:docs/openapi.yaml" > /tmp/openapi-base.yaml
 
-      - name: 破壊的変更を検知
-        if: steps.label-check.outputs.skip == 'false'
-        run: |
+          # 破壊的変更を検知
           echo "=== OpenAPI 破壊的変更チェック ==="
-          echo "ベース: origin/${{ github.base_ref }}"
+          echo "ベース: origin/$BASE_REF"
           echo "PR: $(git rev-parse --short HEAD)"
           oasdiff breaking /tmp/openapi-base.yaml docs/openapi.yaml --fail-on ERR
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
           cache: false
 
       - name: Install oasdiff
-        run: go install github.com/tufin/oasdiff@latest
+        run: go install github.com/oasdiff/oasdiff@latest
 
       - name: Detect OpenAPI breaking changes
         env:

--- a/apps/backend/test/languages.spec.ts
+++ b/apps/backend/test/languages.spec.ts
@@ -1,0 +1,91 @@
+import { SELF, env } from 'cloudflare:test';
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { LanguagesResponse } from '@gh-trend-tracker/shared';
+
+beforeAll(async () => {
+  const db = env.DB as D1Database;
+
+  await db
+    .prepare(
+      `CREATE TABLE IF NOT EXISTS repositories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id INTEGER UNIQUE NOT NULL,
+    name TEXT NOT NULL,
+    full_name TEXT UNIQUE NOT NULL,
+    owner TEXT NOT NULL,
+    language TEXT,
+    description TEXT,
+    html_url TEXT NOT NULL,
+    homepage TEXT,
+    topics TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    pushed_at TEXT
+  )`
+    )
+    .run();
+
+  await db
+    .prepare(
+      `INSERT INTO repositories (repo_id, name, full_name, owner, language, description, html_url, created_at, updated_at)
+    VALUES (1, 'react', 'facebook/react', 'facebook', 'JavaScript', 'A declarative UI library', 'https://github.com/facebook/react', '2024-01-01', '2024-06-01')`
+    )
+    .run();
+  await db
+    .prepare(
+      `INSERT INTO repositories (repo_id, name, full_name, owner, language, description, html_url, created_at, updated_at)
+    VALUES (2, 'vue', 'vuejs/vue', 'vuejs', 'TypeScript', 'Progressive JavaScript Framework', 'https://github.com/vuejs/vue', '2024-01-01', '2024-06-01')`
+    )
+    .run();
+  await db
+    .prepare(
+      `INSERT INTO repositories (repo_id, name, full_name, owner, language, description, html_url, created_at, updated_at)
+    VALUES (3, 'svelte', 'sveltejs/svelte', 'sveltejs', 'TypeScript', 'Cybernetically enhanced web apps', 'https://github.com/sveltejs/svelte', '2024-01-01', '2024-06-01')`
+    )
+    .run();
+  await db
+    .prepare(
+      `INSERT INTO repositories (repo_id, name, full_name, owner, language, description, html_url, created_at, updated_at)
+    VALUES (4, 'no-lang-repo', 'example/no-lang-repo', 'example', NULL, 'No language repo', 'https://github.com/example/no-lang-repo', '2024-01-01', '2024-06-01')`
+    )
+    .run();
+});
+
+describe('/api/languages', () => {
+  describe('正常レスポンス', () => {
+    it('languages 配列を含む 200 レスポンスが返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/languages');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as LanguagesResponse;
+      expect(data).toHaveProperty('languages');
+      expect(Array.isArray(data.languages)).toBe(true);
+    });
+
+    it('language が NULL のリポジトリは除外されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/languages');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as LanguagesResponse;
+      expect(data.languages.every((lang) => lang !== null)).toBe(true);
+    });
+
+    it('重複なしで言語一覧が返されること（TypeScript は1件のみ）', async () => {
+      const response = await SELF.fetch('http://example.com/api/languages');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as LanguagesResponse;
+      const tsCount = data.languages.filter((lang) => lang === 'TypeScript').length;
+      expect(tsCount).toBe(1);
+    });
+
+    it('登録リポジトリの言語がすべて含まれること', async () => {
+      const response = await SELF.fetch('http://example.com/api/languages');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as LanguagesResponse;
+      expect(data.languages).toContain('JavaScript');
+      expect(data.languages).toContain('TypeScript');
+    });
+  });
+});

--- a/apps/backend/test/repositories.spec.ts
+++ b/apps/backend/test/repositories.spec.ts
@@ -1,0 +1,196 @@
+import { SELF, env } from 'cloudflare:test';
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { RepoDetailResponse, HistoryResponse } from '@gh-trend-tracker/shared';
+
+beforeAll(async () => {
+  const db = env.DB as D1Database;
+
+  await db
+    .prepare(
+      `CREATE TABLE IF NOT EXISTS repositories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id INTEGER UNIQUE NOT NULL,
+    name TEXT NOT NULL,
+    full_name TEXT UNIQUE NOT NULL,
+    owner TEXT NOT NULL,
+    language TEXT,
+    description TEXT,
+    html_url TEXT NOT NULL,
+    homepage TEXT,
+    topics TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    pushed_at TEXT
+  )`
+    )
+    .run();
+
+  await db
+    .prepare(
+      `CREATE TABLE IF NOT EXISTS repo_snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id INTEGER NOT NULL,
+    stars INTEGER NOT NULL DEFAULT 0,
+    forks INTEGER NOT NULL DEFAULT 0,
+    watchers INTEGER NOT NULL DEFAULT 0,
+    open_issues INTEGER NOT NULL DEFAULT 0,
+    snapshot_date TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (repo_id) REFERENCES repositories(repo_id) ON DELETE CASCADE,
+    UNIQUE(repo_id, snapshot_date)
+  )`
+    )
+    .run();
+
+  await db
+    .prepare(
+      `INSERT INTO repositories (repo_id, name, full_name, owner, language, description, html_url, homepage, topics, created_at, updated_at)
+    VALUES (1, 'react', 'facebook/react', 'facebook', 'JavaScript', 'A declarative UI library', 'https://github.com/facebook/react', 'https://react.dev', '["ui","javascript"]', '2024-01-01', '2024-06-01')`
+    )
+    .run();
+
+  // 最新スナップショット（7件分）を登録して週間成長率の計算に対応
+  for (let i = 0; i < 7; i++) {
+    const date = new Date('2026-02-09');
+    date.setDate(date.getDate() - i);
+    const dateStr = date.toISOString().split('T')[0];
+    const stars = 230000 - i * 100;
+    await db
+      .prepare(
+        `INSERT INTO repo_snapshots (repo_id, stars, forks, watchers, open_issues, snapshot_date)
+      VALUES (1, ?, 47000, 6700, 900, ?)`
+      )
+      .bind(stars, dateStr)
+      .run();
+  }
+});
+
+describe('/api/repositories/:repoId', () => {
+  describe('正常レスポンス', () => {
+    it('repository・currentStats・weeklyGrowth を含む 200 レスポンスが返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/1');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as RepoDetailResponse;
+      expect(data).toHaveProperty('repository');
+      expect(data).toHaveProperty('currentStats');
+      expect(data).toHaveProperty('weeklyGrowth');
+      expect(data).toHaveProperty('weeklyGrowthRate');
+    });
+
+    it('repository フィールドに必須プロパティが含まれること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/1');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as RepoDetailResponse;
+      const repo = data.repository;
+      expect(repo).toHaveProperty('repoId', 1);
+      expect(repo).toHaveProperty('name', 'react');
+      expect(repo).toHaveProperty('fullName', 'facebook/react');
+      expect(repo).toHaveProperty('owner', 'facebook');
+      expect(repo).toHaveProperty('language', 'JavaScript');
+      expect(repo).toHaveProperty('htmlUrl');
+      expect(Array.isArray(repo.topics)).toBe(true);
+    });
+
+    it('currentStats にスター数・フォーク数が含まれること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/1');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as RepoDetailResponse;
+      const stats = data.currentStats;
+      expect(stats).not.toBeNull();
+      expect(stats).toHaveProperty('stars');
+      expect(stats).toHaveProperty('forks');
+      expect(stats).toHaveProperty('watchers');
+      expect(stats).toHaveProperty('openIssues');
+      expect(stats).toHaveProperty('snapshotDate');
+    });
+
+    it('topics が JSON 配列として正しくパースされること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/1');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as RepoDetailResponse;
+      expect(data.repository.topics).toEqual(['ui', 'javascript']);
+    });
+  });
+
+  describe('バリデーション・エラー', () => {
+    it('存在しない repoId を指定したら 404 が返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/99999');
+      expect(response.status).toBe(404);
+
+      const data = (await response.json()) as { error: string; code: string };
+      expect(data).toHaveProperty('error');
+      expect(data).toHaveProperty('code', 'NOT_FOUND');
+    });
+
+    it('repoId に文字列を指定したら 400 が返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/abc');
+      expect(response.status).toBe(400);
+
+      const data = (await response.json()) as { error: string; code: string };
+      expect(data).toHaveProperty('error');
+      expect(data).toHaveProperty('code', 'VALIDATION_ERROR');
+    });
+
+    it('repoId に 0 を指定したら 400 が返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/0');
+      expect(response.status).toBe(400);
+    });
+  });
+});
+
+describe('/api/repositories/:repoId/history', () => {
+  describe('正常レスポンス', () => {
+    it('history 配列を含む 200 レスポンスが返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/1/history');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as HistoryResponse;
+      expect(data).toHaveProperty('history');
+      expect(Array.isArray(data.history)).toBe(true);
+      expect(data.history.length).toBeGreaterThan(0);
+    });
+
+    it('history アイテムにスナップショットの必須フィールドが含まれること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/1/history');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as HistoryResponse;
+      const item = data.history[0];
+      expect(item).toHaveProperty('repoId');
+      expect(item).toHaveProperty('stars');
+      expect(item).toHaveProperty('forks');
+      expect(item).toHaveProperty('snapshotDate');
+    });
+
+    it('history が日付の降順で返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/1/history');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as HistoryResponse;
+      expect(data.history.length).toBeGreaterThan(1);
+
+      for (let i = 0; i < data.history.length - 1; i++) {
+        expect(data.history[i].snapshotDate >= data.history[i + 1].snapshotDate).toBe(true);
+      }
+    });
+  });
+
+  describe('エラー', () => {
+    it('スナップショットが存在しない repoId を指定したら 404 が返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/99999/history');
+      expect(response.status).toBe(404);
+
+      const data = (await response.json()) as { code: string };
+      expect(data).toHaveProperty('code', 'NOT_FOUND');
+    });
+
+    it('repoId に文字列を指定したら 400 が返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/abc/history');
+      expect(response.status).toBe(400);
+    });
+  });
+});

--- a/apps/backend/test/trends-weekly.spec.ts
+++ b/apps/backend/test/trends-weekly.spec.ts
@@ -1,0 +1,175 @@
+import { SELF, env } from 'cloudflare:test';
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { WeeklyTrendResponse, AvailableWeeksResponse } from '@gh-trend-tracker/shared';
+
+beforeAll(async () => {
+  const db = env.DB as D1Database;
+
+  await db
+    .prepare(
+      `CREATE TABLE IF NOT EXISTS ranking_weekly (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    year INTEGER NOT NULL,
+    week_number INTEGER NOT NULL,
+    language TEXT NOT NULL DEFAULT 'all',
+    rank_data TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`
+    )
+    .run();
+
+  const rankData = JSON.stringify([
+    { rank: 1, repo_id: 1, repo_full_name: 'facebook/react', star_increase: 800 },
+    { rank: 2, repo_id: 2, repo_full_name: 'vuejs/vue', star_increase: 600 },
+    { rank: 3, repo_id: 3, repo_full_name: 'sveltejs/svelte', star_increase: 400 },
+  ]);
+
+  await db
+    .prepare(
+      `INSERT INTO ranking_weekly (year, week_number, language, rank_data)
+    VALUES (2026, 6, 'all', ?)`
+    )
+    .bind(rankData)
+    .run();
+
+  await db
+    .prepare(
+      `INSERT INTO ranking_weekly (year, week_number, language, rank_data)
+    VALUES (2026, 6, 'TypeScript', ?)`
+    )
+    .bind(JSON.stringify([{ rank: 1, repo_id: 2, repo_full_name: 'vuejs/vue', star_increase: 600 }]))
+    .run();
+
+  await db
+    .prepare(
+      `INSERT INTO ranking_weekly (year, week_number, language, rank_data)
+    VALUES (2026, 5, 'all', ?)`
+    )
+    .bind(JSON.stringify([{ rank: 1, repo_id: 1, repo_full_name: 'facebook/react', star_increase: 700 }]))
+    .run();
+});
+
+describe('/api/trends/weekly', () => {
+  describe('正常レスポンス', () => {
+    it('metadata・ranking を含む 200 レスポンスが返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/trends/weekly?year=2026&week=6');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as WeeklyTrendResponse;
+      expect(data).toHaveProperty('metadata');
+      expect(data).toHaveProperty('ranking');
+      expect(Array.isArray(data.ranking)).toBe(true);
+    });
+
+    it('metadata に year・week・language が含まれること', async () => {
+      const response = await SELF.fetch('http://example.com/api/trends/weekly?year=2026&week=6');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as WeeklyTrendResponse;
+      expect(data.metadata).toHaveProperty('year', 2026);
+      expect(data.metadata).toHaveProperty('week', 6);
+      expect(data.metadata).toHaveProperty('language', 'all');
+    });
+
+    it('ranking アイテムに rank・repo_id・repo_full_name・star_increase が含まれること', async () => {
+      const response = await SELF.fetch('http://example.com/api/trends/weekly?year=2026&week=6');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as WeeklyTrendResponse;
+      expect(data.ranking.length).toBe(3);
+
+      const item = data.ranking[0];
+      expect(item).toHaveProperty('rank', 1);
+      expect(item).toHaveProperty('repo_id');
+      expect(item).toHaveProperty('repo_full_name', 'facebook/react');
+      expect(item).toHaveProperty('star_increase', 800);
+    });
+
+    it('language パラメータを指定したら該当言語のランキングが返されること', async () => {
+      const response = await SELF.fetch(
+        'http://example.com/api/trends/weekly?year=2026&week=6&language=TypeScript'
+      );
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as WeeklyTrendResponse;
+      expect(data.metadata.language).toBe('TypeScript');
+      expect(data.ranking.length).toBe(1);
+      expect(data.ranking[0].repo_full_name).toBe('vuejs/vue');
+    });
+  });
+
+  describe('バリデーション・エラー', () => {
+    it('year を省略したら 400 が返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/trends/weekly?week=6');
+      expect(response.status).toBe(400);
+
+      const data = (await response.json()) as { code: string };
+      expect(data).toHaveProperty('code', 'VALIDATION_ERROR');
+    });
+
+    it('week を省略したら 400 が返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/trends/weekly?year=2026');
+      expect(response.status).toBe(400);
+
+      const data = (await response.json()) as { code: string };
+      expect(data).toHaveProperty('code', 'VALIDATION_ERROR');
+    });
+
+    it('データが存在しない week を指定したら 404 が返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/trends/weekly?year=2026&week=52');
+      expect(response.status).toBe(404);
+
+      const data = (await response.json()) as { code: string };
+      expect(data).toHaveProperty('code', 'NOT_FOUND');
+    });
+  });
+});
+
+describe('/api/trends/weekly-available', () => {
+  describe('正常レスポンス', () => {
+    it('weeks 配列を含む 200 レスポンスが返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/trends/weekly/available-weeks');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as AvailableWeeksResponse;
+      expect(data).toHaveProperty('weeks');
+      expect(Array.isArray(data.weeks)).toBe(true);
+    });
+
+    it('weeks アイテムに year・week が含まれること', async () => {
+      const response = await SELF.fetch('http://example.com/api/trends/weekly/available-weeks');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as AvailableWeeksResponse;
+      expect(data.weeks.length).toBeGreaterThan(0);
+
+      const item = data.weeks[0];
+      expect(item).toHaveProperty('year');
+      expect(item).toHaveProperty('week');
+      expect(typeof item.year).toBe('number');
+      expect(typeof item.week).toBe('number');
+    });
+
+    it('重複なし（同一 year/week の複数 language は1件に集約）で返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/trends/weekly/available-weeks');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as AvailableWeeksResponse;
+      // year=2026,week=6 は all と TypeScript の2レコードあるが、集約後は1件
+      const week6 = data.weeks.filter((w) => w.year === 2026 && w.week === 6);
+      expect(week6.length).toBe(1);
+    });
+
+    it('最新週から降順で返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/trends/weekly/available-weeks');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as AvailableWeeksResponse;
+      expect(data.weeks.length).toBeGreaterThan(1);
+
+      // 最初のアイテムが week=6、次が week=5
+      expect(data.weeks[0].week).toBe(6);
+      expect(data.weeks[1].week).toBe(5);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- 未テストだった3エンドポイント（`/api/languages`、`/api/repositories/:repoId`、`/api/trends/weekly`）に統合テストを追加し、全エンドポイントのレスポンス契約を自動検証できるようにした
- CI に `oasdiff` を使った OpenAPI 破壊的変更検知ジョブを追加し、PR でフィールド削除・エンドポイント削除などの破壊的変更を自動検知できるようにした
- `breaking-change` GitHub ラベルを作成し、意図的な破壊的変更時にチェックを迂回できる仕組みを導入した

## Changes

### 新規テストファイル（195テスト → 全パス）

| ファイル | エンドポイント | テスト内容 |
|---|---|---|
| `apps/backend/test/languages.spec.ts` | `GET /api/languages` | レスポンス形・NULL除外・重複排除 |
| `apps/backend/test/repositories.spec.ts` | `GET /api/repositories/:repoId` / `/history` | レスポンス形・topics パース・404/400 エラー・降順ソート |
| `apps/backend/test/trends-weekly.spec.ts` | `GET /api/trends/weekly` / `/available-weeks` | ranking構造・metadata・language フィルタ・404/400・降順・重複集約 |

### CI 変更（`.github/workflows/ci.yml`）

- **Stage 7 追加**: `openapi-breaking-change` ジョブ（PR のみ実行）
  - `breaking-change` ラベルが付与されている場合はスキップ
  - `oasdiff breaking` でベースブランチと差分を比較、ERR 検知時に CI 失敗
- **Stage 8**: 既存の Security Audit ジョブ（番号更新のみ）

### GitHub ラベル

- `breaking-change`（色: `#d93f0b`）を作成済み

## Test plan

- [x] `npm run test --workspace=apps/backend` で 195テスト全パス確認
- [x] `npm run lint --workspace=apps/backend -- --max-warnings=0` パス
- [x] `npm run type-check` パス
- [ ] CI の `openapi-breaking-change` ジョブが PR で正常動作することを確認
- [ ] フィールド削除を含む PR で CI が失敗することを確認
- [ ] `breaking-change` ラベル付き PR でチェックがスキップされることを確認

Closes #156

https://claude.ai/code/session_0166412jHXpne7W1yucss8Ct

---
_Generated by [Claude Code](https://claude.ai/code/session_0166412jHXpne7W1yucss8Ct)_