### PR TITLE
test(api): API互換性統合テストとoasdiff破壊的変更チェックを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,15 +186,15 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/tufin/oasdiff/main/install.sh | sh -s -- -b /usr/local/bin
 
-      - name: main ブランチの openapi.json を取得
+      - name: main ブランチの openapi.yaml を取得
         if: steps.check-label.outputs.skip == 'false'
         run: |
-          git show origin/main:"docs/設計/openapi.json" > /tmp/openapi-base.json
+          git show origin/main:docs/openapi.yaml > /tmp/openapi-base.yaml
 
       - name: 破壊的変更チェック
         if: steps.check-label.outputs.skip == 'false'
         run: |
-          oasdiff breaking /tmp/openapi-base.json "docs/設計/openapi.json" --format text
+          oasdiff breaking /tmp/openapi-base.yaml docs/openapi.yaml --format text
 
   # Stage 8: Security audit
   security:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,46 @@ jobs:
         working-directory: apps/backend
         run: npx drizzle-kit check 2>&1 || true
 
-  # Stage 7: Security audit
+  # Stage 7: OpenAPI破壊的変更チェック（breaking-changeラベルでバイパス可能）
+  openapi-breaking-change:
+    name: OpenAPI Breaking Change Check
+    runs-on: ubuntu-latest
+    # PRイベントのみ実行（pushやworkflow_callはスキップ）
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: breaking-changeラベルの確認
+        id: check-label
+        run: |
+          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+          if echo "$LABELS" | grep -q '"breaking-change"'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::breaking-change ラベルが付与されているため OpenAPI 破壊的変更チェックをスキップします"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: oasdiff のインストール
+        if: steps.check-label.outputs.skip == 'false'
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/tufin/oasdiff/main/install.sh | sh -s -- -b /usr/local/bin
+
+      - name: main ブランチの openapi.json を取得
+        if: steps.check-label.outputs.skip == 'false'
+        run: |
+          git show origin/main:"docs/設計/openapi.json" > /tmp/openapi-base.json
+
+      - name: 破壊的変更チェック
+        if: steps.check-label.outputs.skip == 'false'
+        run: |
+          oasdiff breaking /tmp/openapi-base.json "docs/設計/openapi.json" --format text
+
+  # Stage 8: Security audit
   security:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/apps/backend/test/languages.spec.ts
+++ b/apps/backend/test/languages.spec.ts
@@ -1,0 +1,87 @@
+import { SELF, env } from 'cloudflare:test';
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { LanguagesResponse } from '@gh-trend-tracker/shared';
+
+beforeAll(async () => {
+  const db = env.DB as D1Database;
+
+  await db
+    .prepare(
+      `CREATE TABLE IF NOT EXISTS repositories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id INTEGER UNIQUE NOT NULL,
+    name TEXT NOT NULL,
+    full_name TEXT UNIQUE NOT NULL,
+    owner TEXT NOT NULL,
+    language TEXT,
+    description TEXT,
+    html_url TEXT NOT NULL,
+    homepage TEXT,
+    topics TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    pushed_at TEXT
+  )`
+    )
+    .run();
+
+  await db
+    .prepare(
+      `INSERT INTO repositories (repo_id, name, full_name, owner, language, html_url, created_at, updated_at) VALUES (101, 'react', 'facebook/react', 'facebook', 'JavaScript', 'https://github.com/facebook/react', '2024-01-01', '2024-06-01')`
+    )
+    .run();
+  await db
+    .prepare(
+      `INSERT INTO repositories (repo_id, name, full_name, owner, language, html_url, created_at, updated_at) VALUES (102, 'typescript', 'microsoft/typescript', 'microsoft', 'TypeScript', 'https://github.com/microsoft/typescript', '2024-01-01', '2024-06-01')`
+    )
+    .run();
+  await db
+    .prepare(
+      `INSERT INTO repositories (repo_id, name, full_name, owner, language, html_url, created_at, updated_at) VALUES (103, 'vue', 'vuejs/vue', 'vuejs', 'TypeScript', 'https://github.com/vuejs/vue', '2024-01-01', '2024-06-01')`
+    )
+    .run();
+  // language が NULL のリポジトリ（言語一覧には含まれない）
+  await db
+    .prepare(
+      `INSERT INTO repositories (repo_id, name, full_name, owner, language, html_url, created_at, updated_at) VALUES (104, 'dotfiles', 'user/dotfiles', 'user', NULL, 'https://github.com/user/dotfiles', '2024-01-01', '2024-06-01')`
+    )
+    .run();
+});
+
+describe('/api/languages', () => {
+  it('languagesフィールドを含む200レスポンスが返されること', async () => {
+    const response = await SELF.fetch('http://example.com/api/languages');
+    expect(response.status).toBe(200);
+
+    const data = (await response.json()) as LanguagesResponse;
+
+    expect(data).toHaveProperty('languages');
+    expect(Array.isArray(data.languages)).toBe(true);
+  });
+
+  it('NULLの言語が除外されること', async () => {
+    const response = await SELF.fetch('http://example.com/api/languages');
+    expect(response.status).toBe(200);
+
+    const data = (await response.json()) as LanguagesResponse;
+    expect(data.languages.every((l) => l !== null)).toBe(true);
+  });
+
+  it('重複する言語が1件にまとめられること', async () => {
+    const response = await SELF.fetch('http://example.com/api/languages');
+    expect(response.status).toBe(200);
+
+    const data = (await response.json()) as LanguagesResponse;
+    const uniqueLanguages = new Set(data.languages);
+    expect(data.languages.length).toBe(uniqueLanguages.size);
+  });
+
+  it('期待する言語が含まれること', async () => {
+    const response = await SELF.fetch('http://example.com/api/languages');
+    expect(response.status).toBe(200);
+
+    const data = (await response.json()) as LanguagesResponse;
+    expect(data.languages).toContain('JavaScript');
+    expect(data.languages).toContain('TypeScript');
+  });
+});

--- a/apps/backend/test/repositories.spec.ts
+++ b/apps/backend/test/repositories.spec.ts
@@ -1,0 +1,245 @@
+import { SELF, env } from 'cloudflare:test';
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { RepoDetailResponse, HistoryResponse, ApiError } from '@gh-trend-tracker/shared';
+
+beforeAll(async () => {
+  const db = env.DB as D1Database;
+
+  await db
+    .prepare(
+      `CREATE TABLE IF NOT EXISTS repositories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id INTEGER UNIQUE NOT NULL,
+    name TEXT NOT NULL,
+    full_name TEXT UNIQUE NOT NULL,
+    owner TEXT NOT NULL,
+    language TEXT,
+    description TEXT,
+    html_url TEXT NOT NULL,
+    homepage TEXT,
+    topics TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    pushed_at TEXT
+  )`
+    )
+    .run();
+
+  await db
+    .prepare(
+      `CREATE TABLE IF NOT EXISTS repo_snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo_id INTEGER NOT NULL,
+    stars INTEGER NOT NULL DEFAULT 0,
+    forks INTEGER NOT NULL DEFAULT 0,
+    watchers INTEGER NOT NULL DEFAULT 0,
+    open_issues INTEGER NOT NULL DEFAULT 0,
+    snapshot_date TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (repo_id) REFERENCES repositories(repo_id) ON DELETE CASCADE,
+    UNIQUE(repo_id, snapshot_date)
+  )`
+    )
+    .run();
+
+  await db
+    .prepare(
+      `INSERT INTO repositories (repo_id, name, full_name, owner, language, description, html_url, homepage, topics, created_at, updated_at)
+    VALUES (10, 'typescript', 'microsoft/typescript', 'microsoft', 'TypeScript', 'TypeScript compiler', 'https://github.com/microsoft/typescript', 'https://typescriptlang.org', '["compiler","language"]', '2024-01-01', '2024-06-01')`
+    )
+    .run();
+
+  // weeklyGrowthRate計算には7件のスナップショットが必要（snapshots[6]が7日前）
+  await db
+    .prepare(
+      `INSERT INTO repo_snapshots (repo_id, stars, forks, watchers, open_issues, snapshot_date) VALUES (10, 100000, 12000, 3000, 500, '2026-02-09')`
+    )
+    .run();
+  await db
+    .prepare(
+      `INSERT INTO repo_snapshots (repo_id, stars, forks, watchers, open_issues, snapshot_date) VALUES (10, 99800, 11980, 2995, 498, '2026-02-08')`
+    )
+    .run();
+  await db
+    .prepare(
+      `INSERT INTO repo_snapshots (repo_id, stars, forks, watchers, open_issues, snapshot_date) VALUES (10, 99600, 11960, 2990, 496, '2026-02-07')`
+    )
+    .run();
+  await db
+    .prepare(
+      `INSERT INTO repo_snapshots (repo_id, stars, forks, watchers, open_issues, snapshot_date) VALUES (10, 99400, 11940, 2985, 494, '2026-02-06')`
+    )
+    .run();
+  await db
+    .prepare(
+      `INSERT INTO repo_snapshots (repo_id, stars, forks, watchers, open_issues, snapshot_date) VALUES (10, 99200, 11920, 2982, 492, '2026-02-05')`
+    )
+    .run();
+  await db
+    .prepare(
+      `INSERT INTO repo_snapshots (repo_id, stars, forks, watchers, open_issues, snapshot_date) VALUES (10, 99100, 11910, 2981, 491, '2026-02-04')`
+    )
+    .run();
+  // 7件目（snapshots[6]）= 7日前のスナップショット
+  await db
+    .prepare(
+      `INSERT INTO repo_snapshots (repo_id, stars, forks, watchers, open_issues, snapshot_date) VALUES (10, 99000, 11900, 2980, 490, '2026-02-03')`
+    )
+    .run();
+});
+
+describe('/api/repositories/:repoId', () => {
+  describe('バリデーション', () => {
+    it('repoIdに文字列を指定したら400エラーが返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/abc');
+      expect(response.status).toBe(400);
+
+      const data = (await response.json()) as ApiError;
+      expect(data).toHaveProperty('error');
+      expect(data).toHaveProperty('code', 'VALIDATION_ERROR');
+    });
+
+    it('repoIdに0を指定したら400エラーが返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/0');
+      expect(response.status).toBe(400);
+    });
+
+    it('repoIdに負の整数を指定したら400エラーが返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/-1');
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('正常レスポンス', () => {
+    it('存在するrepoIdを指定したらrepository・currentStats・weeklyGrowthを含む200レスポンスが返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/10');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as RepoDetailResponse;
+
+      expect(data).toHaveProperty('repository');
+      expect(data).toHaveProperty('currentStats');
+      expect(data).toHaveProperty('weeklyGrowth');
+      expect(data).toHaveProperty('weeklyGrowthRate');
+    });
+
+    it('repositoryオブジェクトに必須フィールドが含まれること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/10');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as RepoDetailResponse;
+      const repo = data.repository;
+
+      expect(repo).toHaveProperty('repoId', 10);
+      expect(repo).toHaveProperty('name', 'typescript');
+      expect(repo).toHaveProperty('fullName', 'microsoft/typescript');
+      expect(repo).toHaveProperty('owner', 'microsoft');
+      expect(repo).toHaveProperty('language', 'TypeScript');
+      expect(repo).toHaveProperty('description', 'TypeScript compiler');
+      expect(repo).toHaveProperty('htmlUrl');
+      expect(repo).toHaveProperty('homepage');
+      expect(Array.isArray(repo.topics)).toBe(true);
+    });
+
+    it('topicsがJSON文字列からパースされた配列として返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/10');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as RepoDetailResponse;
+      expect(data.repository.topics).toEqual(['compiler', 'language']);
+    });
+
+    it('currentStatsにスナップショット情報が含まれること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/10');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as RepoDetailResponse;
+      const stats = data.currentStats;
+
+      expect(stats).not.toBeNull();
+      expect(stats).toHaveProperty('stars', 100000);
+      expect(stats).toHaveProperty('forks', 12000);
+      expect(stats).toHaveProperty('watchers', 3000);
+      expect(stats).toHaveProperty('openIssues', 500);
+      expect(stats).toHaveProperty('snapshotDate', '2026-02-09');
+    });
+
+    it('weeklyGrowthとweeklyGrowthRateが正しく計算されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/10');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as RepoDetailResponse;
+      // 100000 - 99000 = 1000
+      expect(data.weeklyGrowth).toBe(1000);
+      // (1000 / 99000) * 100 ≒ 1.01%
+      expect(data.weeklyGrowthRate).toBeCloseTo(1.01, 0);
+    });
+  });
+
+  describe('404', () => {
+    it('存在しないrepoIdを指定したら404エラーが返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/99999');
+      expect(response.status).toBe(404);
+
+      const data = (await response.json()) as ApiError;
+      expect(data).toHaveProperty('error');
+      expect(data).toHaveProperty('code', 'NOT_FOUND');
+    });
+  });
+});
+
+describe('/api/repositories/:repoId/history', () => {
+  describe('バリデーション', () => {
+    it('repoIdに文字列を指定したら400エラーが返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/abc/history');
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('正常レスポンス', () => {
+    it('存在するrepoIdを指定したらhistory配列を含む200レスポンスが返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/10/history');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as HistoryResponse;
+
+      expect(data).toHaveProperty('history');
+      expect(Array.isArray(data.history)).toBe(true);
+      expect(data.history.length).toBeGreaterThan(0);
+    });
+
+    it('historyの各アイテムに必須フィールドが含まれること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/10/history');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as HistoryResponse;
+      const item = data.history[0];
+
+      expect(item).toHaveProperty('repoId', 10);
+      expect(item).toHaveProperty('stars');
+      expect(item).toHaveProperty('forks');
+      expect(item).toHaveProperty('watchers');
+      expect(item).toHaveProperty('openIssues');
+      expect(item).toHaveProperty('snapshotDate');
+    });
+
+    it('historyが日付の降順で返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/10/history');
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as HistoryResponse;
+      expect(data.history[0].snapshotDate).toBe('2026-02-09');
+      expect(data.history[1].snapshotDate).toBe('2026-02-08');
+    });
+  });
+
+  describe('404', () => {
+    it('存在しないrepoIdを指定したら404エラーが返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/repositories/99999/history');
+      expect(response.status).toBe(404);
+
+      const data = (await response.json()) as ApiError;
+      expect(data).toHaveProperty('code', 'NOT_FOUND');
+    });
+  });
+});

--- a/apps/backend/test/trends-weekly.spec.ts
+++ b/apps/backend/test/trends-weekly.spec.ts
@@ -1,0 +1,217 @@
+import { SELF, env } from 'cloudflare:test';
+import { describe, it, expect, beforeAll } from 'vitest';
+import type { WeeklyTrendResponse, AvailableWeeksResponse, ApiError } from '@gh-trend-tracker/shared';
+
+const SAMPLE_RANK_DATA = JSON.stringify([
+  { rank: 1, repo_id: 1, repo_full_name: 'facebook/react', star_increase: 500 },
+  { rank: 2, repo_id: 2, repo_full_name: 'vuejs/vue', star_increase: 300 },
+]);
+
+beforeAll(async () => {
+  const db = env.DB as D1Database;
+
+  await db
+    .prepare(
+      `CREATE TABLE IF NOT EXISTS ranking_weekly (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    year INTEGER NOT NULL,
+    week_number INTEGER NOT NULL,
+    language TEXT NOT NULL DEFAULT 'all',
+    rank_data TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`
+    )
+    .run();
+
+  // 2026年第5週 全言語
+  await db
+    .prepare(
+      `INSERT INTO ranking_weekly (year, week_number, language, rank_data) VALUES (2026, 5, 'all', ?)`
+    )
+    .bind(SAMPLE_RANK_DATA)
+    .run();
+
+  // 2026年第5週 TypeScript
+  await db
+    .prepare(
+      `INSERT INTO ranking_weekly (year, week_number, language, rank_data) VALUES (2026, 5, 'TypeScript', ?)`
+    )
+    .bind(SAMPLE_RANK_DATA)
+    .run();
+
+  // 2026年第4週 全言語
+  await db
+    .prepare(
+      `INSERT INTO ranking_weekly (year, week_number, language, rank_data) VALUES (2026, 4, 'all', ?)`
+    )
+    .bind(SAMPLE_RANK_DATA)
+    .run();
+});
+
+describe('/api/trends/weekly', () => {
+  describe('バリデーション', () => {
+    it('yearとweekを省略したら400エラーが返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/trends/weekly');
+      expect(response.status).toBe(400);
+
+      const data = (await response.json()) as ApiError;
+      expect(data).toHaveProperty('error');
+      expect(data).toHaveProperty('code', 'VALIDATION_ERROR');
+    });
+
+    it('weekのみ省略したら400エラーが返されること', async () => {
+      const response = await SELF.fetch('http://example.com/api/trends/weekly?year=2026');
+      expect(response.status).toBe(400);
+    });
+
+    it('weekに0を指定したら400エラーが返されること', async () => {
+      const response = await SELF.fetch(
+        'http://example.com/api/trends/weekly?year=2026&week=0'
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it('weekに54を指定したら400エラーが返されること', async () => {
+      const response = await SELF.fetch(
+        'http://example.com/api/trends/weekly?year=2026&week=54'
+      );
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('正常レスポンス', () => {
+    it('有効なyear・weekを指定したらmetadata・rankingを含む200レスポンスが返されること', async () => {
+      const response = await SELF.fetch(
+        'http://example.com/api/trends/weekly?year=2026&week=5'
+      );
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as WeeklyTrendResponse;
+
+      expect(data).toHaveProperty('metadata');
+      expect(data).toHaveProperty('ranking');
+      expect(Array.isArray(data.ranking)).toBe(true);
+    });
+
+    it('metadataに正しいyear・week・languageが含まれること', async () => {
+      const response = await SELF.fetch(
+        'http://example.com/api/trends/weekly?year=2026&week=5'
+      );
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as WeeklyTrendResponse;
+      expect(data.metadata).toEqual({ year: 2026, week: 5, language: 'all' });
+    });
+
+    it('languageを指定したら該当言語のランキングが返されること', async () => {
+      const response = await SELF.fetch(
+        'http://example.com/api/trends/weekly?year=2026&week=5&language=TypeScript'
+      );
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as WeeklyTrendResponse;
+      expect(data.metadata.language).toBe('TypeScript');
+    });
+
+    it('rankingの各アイテムにrank・repo_id・repo_full_name・star_increaseが含まれること', async () => {
+      const response = await SELF.fetch(
+        'http://example.com/api/trends/weekly?year=2026&week=5'
+      );
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as WeeklyTrendResponse;
+      const item = data.ranking[0];
+
+      expect(item).toHaveProperty('rank', 1);
+      expect(item).toHaveProperty('repo_id');
+      expect(typeof item.repo_id).toBe('string');
+      expect(item).toHaveProperty('repo_full_name', 'facebook/react');
+      expect(item).toHaveProperty('star_increase', 500);
+    });
+
+    it('repo_idが文字列として返されること', async () => {
+      const response = await SELF.fetch(
+        'http://example.com/api/trends/weekly?year=2026&week=5'
+      );
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as WeeklyTrendResponse;
+      data.ranking.forEach((item) => {
+        expect(typeof item.repo_id).toBe('string');
+      });
+    });
+  });
+
+  describe('404', () => {
+    it('存在しない週を指定したら404エラーが返されること', async () => {
+      const response = await SELF.fetch(
+        'http://example.com/api/trends/weekly?year=2025&week=1'
+      );
+      expect(response.status).toBe(404);
+
+      const data = (await response.json()) as ApiError;
+      expect(data).toHaveProperty('code', 'NOT_FOUND');
+    });
+
+    it('存在しない言語を指定したら404エラーが返されること', async () => {
+      const response = await SELF.fetch(
+        'http://example.com/api/trends/weekly?year=2026&week=5&language=COBOL'
+      );
+      expect(response.status).toBe(404);
+    });
+  });
+});
+
+describe('/api/trends/weekly/available-weeks', () => {
+  it('weeksフィールドを含む200レスポンスが返されること', async () => {
+    const response = await SELF.fetch(
+      'http://example.com/api/trends/weekly/available-weeks'
+    );
+    expect(response.status).toBe(200);
+
+    const data = (await response.json()) as AvailableWeeksResponse;
+
+    expect(data).toHaveProperty('weeks');
+    expect(Array.isArray(data.weeks)).toBe(true);
+  });
+
+  it('各週アイテムにyearとweekが含まれること', async () => {
+    const response = await SELF.fetch(
+      'http://example.com/api/trends/weekly/available-weeks'
+    );
+    expect(response.status).toBe(200);
+
+    const data = (await response.json()) as AvailableWeeksResponse;
+    expect(data.weeks.length).toBeGreaterThan(0);
+
+    const item = data.weeks[0];
+    expect(item).toHaveProperty('year');
+    expect(item).toHaveProperty('week');
+    expect(typeof item.year).toBe('number');
+    expect(typeof item.week).toBe('number');
+  });
+
+  it('週リストが新しい順（降順）で返されること', async () => {
+    const response = await SELF.fetch(
+      'http://example.com/api/trends/weekly/available-weeks'
+    );
+    expect(response.status).toBe(200);
+
+    const data = (await response.json()) as AvailableWeeksResponse;
+    // 2026年第5週が先頭、2026年第4週が後
+    expect(data.weeks[0]).toEqual({ year: 2026, week: 5 });
+    expect(data.weeks[1]).toEqual({ year: 2026, week: 4 });
+  });
+
+  it('languageが異なる場合でも同一週は1件のみ返されること', async () => {
+    const response = await SELF.fetch(
+      'http://example.com/api/trends/weekly/available-weeks'
+    );
+    expect(response.status).toBe(200);
+
+    const data = (await response.json()) as AvailableWeeksResponse;
+    // year=2026, week=5 は 'all' と 'TypeScript' の2レコードあるが available-weeks では1件
+    const week5Entries = data.weeks.filter((w) => w.year === 2026 && w.week === 5);
+    expect(week5Entries.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- `/api/repositories/:repoId` と `/api/repositories/:repoId/history` の統合テストを追加（バリデーション・正常系・404）
- `/api/languages` の統合テストを追加（重複除去・NULL除外の検証を含む）
- `/api/trends/weekly` と `/api/trends/weekly/available-weeks` の統合テストを追加（バリデーション・正常系・404）
- CI に `oasdiff` による OpenAPI 破壊的変更チェックジョブ（Stage 7）を追加
- `breaking-change` ラベル付与でチェックをバイパス可能

## Test plan

- [ ] 既存テストを含む全テスト（201件 backend + 54件 frontend）が通過すること
- [ ] 新規統合テスト 33件 が通過すること（`repositories.spec.ts`, `languages.spec.ts`, `trends-weekly.spec.ts`）
- [ ] CIの `openapi-breaking-change` ジョブが PR イベント時のみ実行されること
- [ ] `breaking-change` ラベル付与時にチェックがスキップされること
- [ ] フィールド削除など破壊的変更を含む PR で CI が失敗すること
- [ ] フィールド追加（optional）の PR は通過すること

## Changes

- `apps/backend/test/repositories.spec.ts` - 新規追加（17テスト）
- `apps/backend/test/languages.spec.ts` - 新規追加（4テスト）
- `apps/backend/test/trends-weekly.spec.ts` - 新規追加（12テスト）
- `.github/workflows/ci.yml` - Stage 7: `openapi-breaking-change` ジョブ追加

Closes #156

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ey4DWKxK1CU53twuVx4WB)_