### PR TITLE
feat(#155): 月次リストアテストworkflowを追加

### DIFF
--- a/.github/workflows/restore-test.yml
+++ b/.github/workflows/restore-test.yml
@@ -12,6 +12,7 @@ on:
 # 実行中は開発用DBが一時的に破壊状態になることに注意
 
 permissions:
+  contents: read
   issues: write
 
 jobs:

--- a/.github/workflows/restore-test.yml
+++ b/.github/workflows/restore-test.yml
@@ -1,0 +1,130 @@
+name: Monthly Restore Test
+
+on:
+  # 毎月1日 UTC 03:00 に実行（日本時間 12:00 PM）
+  schedule:
+    - cron: '0 3 1 * *'
+
+  # 手動実行を許可（動作確認用）
+  workflow_dispatch:
+
+# ⚠️ このワークフローは gh-trends-db-dev を一旦初期化してからリストアする
+# 実行中は開発用DBが一時的に破壊状態になることに注意
+
+permissions:
+  issues: write
+
+jobs:
+  restore-test:
+    name: D1 Restore Test (dev DB)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download latest backup from R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_BACKUP_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_BACKUP_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          LATEST=$(aws s3 ls \
+            "s3://gh-trends-backups/" \
+            --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+            --region auto \
+            | sort | tail -1 | awk '{print $4}')
+          if [ -z "$LATEST" ]; then
+            echo "::error::R2バケットにバックアップファイルが見つかりません"
+            exit 1
+          fi
+          echo "最新バックアップ: ${LATEST}"
+          echo "BACKUP_FILENAME=${LATEST}" >> "$GITHUB_ENV"
+          echo "SQL_FILE=${LATEST%.gz}" >> "$GITHUB_ENV"
+          aws s3 cp \
+            "s3://gh-trends-backups/${LATEST}" \
+            "/tmp/${LATEST}" \
+            --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+            --region auto
+
+      - name: Decompress backup
+        run: gunzip "/tmp/${{ env.BACKUP_FILENAME }}"
+
+      - name: Initialize dev DB
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: |
+          cat > /tmp/reset-dev-db.sql << 'SQL'
+          PRAGMA foreign_keys=OFF;
+          DROP TABLE IF EXISTS ranking_weekly;
+          DROP TABLE IF EXISTS metrics_daily;
+          DROP TABLE IF EXISTS repo_snapshots;
+          DROP TABLE IF EXISTS repositories;
+          DROP TABLE IF EXISTS users;
+          DROP TABLE IF EXISTS languages;
+          DROP TABLE IF EXISTS d1_migrations;
+          DROP TABLE IF EXISTS __drizzle_migrations;
+          PRAGMA foreign_keys=ON;
+          SQL
+          npx wrangler d1 execute gh-trends-db-dev \
+            --env development \
+            --remote \
+            --file /tmp/reset-dev-db.sql
+
+      - name: Apply backup to dev DB
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: |
+          npx wrangler d1 execute gh-trends-db-dev \
+            --env development \
+            --remote \
+            --file "/tmp/${{ env.SQL_FILE }}"
+
+      - name: Run integrity check
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: npm run db:check -- --remote --env development --restore-mode
+
+      - name: Create GitHub Issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const date = new Date().toISOString().slice(0, 10);
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[自動起票] 月次リストアテスト失敗 ${date}`,
+              body: [
+                '## 月次リストアテスト失敗',
+                '',
+                `実行日時: ${new Date().toISOString()}`,
+                `ワークフロー: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+                '',
+                '### 対応手順',
+                '1. 上記ワークフロー実行のログを確認',
+                '2. `docs/プロセス/障害対応Runbook.md` の「DB障害」セクションを参照',
+                '3. R2バケット `gh-trends-backups` にバックアップが存在するか確認',
+                '4. dev DBの状態を手動確認:',
+                '   ```bash',
+                '   cd apps/backend && npm run db:check -- --remote --env development',
+                '   ```',
+              ].join('\n'),
+              labels: ['bug'],
+            });

--- a/apps/backend/scripts/check-db-integrity.ts
+++ b/apps/backend/scripts/check-db-integrity.ts
@@ -13,6 +13,7 @@
  *   npm run db:check                        # ローカルSQLiteを使用
  *   npm run db:check -- --remote            # リモートD1を使用（本番）
  *   npm run db:check -- --env development   # 開発用D1を使用
+ *   npm run db:check -- --restore-mode      # リストアモード（タイムスタンプチェックをスキップ）
  *
  * 終了コード:
  *   0: 全チェック通過
@@ -29,6 +30,7 @@ interface CheckResult {
 
 const args = process.argv.slice(2);
 const isRemote = args.includes('--remote');
+const isRestoreMode = args.includes('--restore-mode');
 const envArg = args.find((a) => a.startsWith('--env'));
 const env = envArg ? envArg.split('=')[1] ?? args[args.indexOf(envArg) + 1] : 'development';
 
@@ -82,22 +84,32 @@ try {
   checks.push({ name: 'repo_snapshots: 行数 > 0', passed: false, message: String(err) });
 }
 
-// 3. metrics_daily の最新レコードが直近24時間以内
+// 3. metrics_daily の最新レコード確認（通常モード: 直近24時間以内、リストアモード: データ存在確認のみ）
 try {
-  const result = query(
-    `SELECT MAX(calculated_date) as latest FROM metrics_daily`
-  );
+  const result = query(`SELECT MAX(calculated_date) as latest FROM metrics_daily`);
   const latest = result.results?.[0]?.latest as string | undefined;
-  const hasRecent = latest !== undefined && latest !== null && latest >= threshold.slice(0, 10);
-  checks.push({
-    name: 'metrics_daily: 最新レコードが直近24時間以内',
-    passed: hasRecent,
-    message: hasRecent
-      ? `最新レコード: ${latest}`
-      : `最新レコード(${latest ?? 'なし'})が24時間以上前です（閾値: ${threshold.slice(0, 10)}）`,
-  });
+  if (isRestoreMode) {
+    const hasData = latest !== undefined && latest !== null;
+    checks.push({
+      name: 'metrics_daily: データ存在確認（リストアモード）',
+      passed: hasData,
+      message: hasData ? `最新レコード: ${latest}` : 'metrics_dailyにデータがありません',
+    });
+  } else {
+    const hasRecent = latest !== undefined && latest !== null && latest >= threshold.slice(0, 10);
+    checks.push({
+      name: 'metrics_daily: 最新レコードが直近24時間以内',
+      passed: hasRecent,
+      message: hasRecent
+        ? `最新レコード: ${latest}`
+        : `最新レコード(${latest ?? 'なし'})が24時間以上前です（閾値: ${threshold.slice(0, 10)}）`,
+    });
+  }
 } catch (err) {
-  checks.push({ name: 'metrics_daily: 最新レコードが直近24時間以内', passed: false, message: String(err) });
+  const name = isRestoreMode
+    ? 'metrics_daily: データ存在確認（リストアモード）'
+    : 'metrics_daily: 最新レコードが直近24時間以内';
+  checks.push({ name, passed: false, message: String(err) });
 }
 
 // 4. ranking_weekly の行数確認

--- a/docs/プロセス/GitHubActions設定.md
+++ b/docs/プロセス/GitHubActions設定.md
@@ -344,6 +344,54 @@ GitHub Actionsのログは90日間保持されます。重要なデータは別�
 
 ---
 
+## 月次リストアテスト（restore-test.yml）
+
+`.github/workflows/restore-test.yml` は毎月1日 UTC 03:00（日本時間 12:00）に R2 バックアップを開発用 D1 DB へリストアし、整合性を自動検証します。
+
+> ⚠️ **注意: このワークフローは `gh-trends-db-dev`（開発用 D1）を一旦全削除してからリストアします。**
+> 実行中は開発用 DB が一時的に破壊された状態になります。ローカル開発中にこのワークフローが実行されると、開発環境の DB が消去されます。
+> 月次リストアテスト中はローカル開発を一時停止するか、ローカル DB（`--local`）を使用してください。
+
+### リストアフロー
+
+```
+毎月1日 UTC 03:00（または手動実行）
+  └─ restore-test ジョブ
+       ├─ R2から最新バックアップを取得 → /tmp/gh-trends-db_YYYY-MM-DD.sql.gz
+       ├─ 解凍 → /tmp/gh-trends-db_YYYY-MM-DD.sql
+       ├─ dev DB 初期化（全テーブル DROP）
+       ├─ バックアップ SQL を dev DB に適用
+       ├─ 整合性チェック（npm run db:check -- --remote --env development --restore-mode）
+       └─ 失敗時 → GitHub Issue を自動起票
+```
+
+### 必要なシークレット
+
+| シークレット名 | 用途 |
+| --- | --- |
+| `R2_BACKUP_ACCESS_KEY_ID` | R2 からバックアップ取得 |
+| `R2_BACKUP_SECRET_ACCESS_KEY` | R2 からバックアップ取得 |
+| `CLOUDFLARE_API_TOKEN` | dev D1 への書き込み |
+| `CLOUDFLARE_ACCOUNT_ID` | R2 エンドポイント・D1 特定 |
+
+### `--restore-mode` フラグ
+
+`npm run db:check` に `--restore-mode` を付けると、タイムスタンプベースのチェック（直近24時間以内）がスキップされ、データ**存在確認**のみ行います。バックアップは古いデータを含むため、通常モードでは必ずタイムスタンプチェックが失敗します。
+
+### 手動実行でテスト
+
+1. GitHub リポジトリの **"Actions"** タブを開く
+2. 左サイドバーの **"Monthly Restore Test"** をクリック
+3. **"Run workflow"** → **"Run workflow"** をクリック
+4. 実行ログで `Run integrity check` ステップが成功することを確認
+
+### 失敗時の対応
+
+ワークフロー失敗時は `[自動起票] 月次リストアテスト失敗 YYYY-MM-DD` という GitHub Issue が自動作成されます。
+Issue の手順に従いワークフローログを確認し、`docs/プロセス/障害対応Runbook.md` の「DB障害」セクションを参照してください。
+
+---
+
 ## 自動デプロイ（deploy.yml）
 
 `.github/workflows/deploy.yml` は `main` ブランチへの push 時または手動トリガーで自動デプロイを実行します。


### PR DESCRIPTION
## Summary

- `.github/workflows/restore-test.yml` を新規追加（毎月1日 UTC 03:00 cron + `workflow_dispatch`）
- R2バックアップをdev DBへリストアし、整合性チェックスクリプトで自動検証する
- 失敗時にGitHub Issueを自動起票する仕組みを実装

## Changes

### `.github/workflows/restore-test.yml`（新規）
- **スケジュール**: 毎月1日 UTC 03:00（+ `workflow_dispatch` で手動実行可能）
- **ステップ**:
  1. R2から最新バックアップ（`.sql.gz`）を取得
  2. 解凍してSQLファイルを生成
  3. `gh-trends-db-dev` を全テーブルDROPで初期化
  4. バックアップSQLを dev DB に適用
  5. `npm run db:check -- --remote --env development --restore-mode` で整合性確認
  6. 失敗時は `[自動起票] 月次リストアテスト失敗 YYYY-MM-DD` のGitHub Issueを自動作成

### `apps/backend/scripts/check-db-integrity.ts`
- `--restore-mode` フラグを追加
- リストアモード時はタイムスタンプベースのチェック（直近24時間以内）をスキップし、データ**存在確認**のみ実施
  - バックアップは古いデータを含むため通常モードでは必ずタイムスタンプチェックが失敗するため

### `docs/プロセス/GitHubActions設定.md`
- 「月次リストアテスト（restore-test.yml）」セクションを追加
- ⚠️ リストアテスト中は `gh-trends-db-dev` が一旦破壊されることを明記

## Test plan

- [ ] `workflow_dispatch` で手動実行し、R2からバックアップ取得 → dev DBへのリストア → 整合性チェックが通過することを確認
- [ ] 失敗ケース（R2にファイルがない等）で GitHub Issue が自動起票されることを確認
- [ ] `npm run db:check -- --restore-mode` でタイムスタンプチェックがスキップされることをローカルで確認

Closes #155

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfUqmSJizrva998qaGmki9)_