### PR TITLE
perf(core): Automated performance tuning by Claude

### DIFF
--- a/apps/backend/src/services/batch-collector.ts
+++ b/apps/backend/src/services/batch-collector.ts
@@ -9,7 +9,6 @@ import {
   getAllRepositoryFullNames,
   batchUpsertRepositories,
   batchInsertSnapshots,
-  getTodaySnapshots,
   calculateAndUpsertMetricsBatch,
 } from './batch-db';
 import type { GitHubRepoData } from './github';
@@ -101,16 +100,14 @@ export async function runDailyCollection(options: CollectOptions): Promise<Batch
     );
   }
 
-  // 4. 全リポジトリのメトリクスをバッチ計算（N+1クエリ問題を解消: O(4N)→O(2)ラウンドトリップ）
+  // 4. 全リポジトリのメトリクスをバッチ計算（todaySnaps取得を内部で7d/30dと並列化: 3RTT→2RTT）
   // DB実値を取得することでonConflictDoNothing後のスナップショット値との一貫性を担保
   if (successResults.length > 0) {
     try {
-      const todaySnaps = await getTodaySnapshots(db, todayDate);
-      await calculateAndUpsertMetricsBatch(db, todaySnaps, todayDate);
+      const snapshotCount = await calculateAndUpsertMetricsBatch(db, todayDate);
       // スナップショット挿入失敗時は実際に書き込まれた件数で成否を判定する。
       // onConflictDoNothingで既存行をスキップした件数も含むため、
-      // todaySnaps.lengthをsuccessの上限として扱う。
-      const snapshotCount = todaySnaps.length;
+      // snapshotCountをsuccessの上限として扱う。
       const missing = successResults.length - snapshotCount;
       dbSuccess = snapshotCount;
       if (snapshotFailed && missing > 0) {

--- a/apps/backend/src/services/batch-db.bench.test.ts
+++ b/apps/backend/src/services/batch-db.bench.test.ts
@@ -342,11 +342,10 @@ describe('calculateAndUpsertMetricsBatch ベンチマーク', () => {
   });
 
   it('正確性確認: バッチ版でも計算結果が変わらない', async () => {
-    const todaySnaps = [
-      { repoId: 1, stars: 1010 },
-      { repoId: 2, stars: 1020 },
-    ];
-    await calculateAndUpsertMetricsBatch(db, todaySnaps, TODAY);
+    const count = await calculateAndUpsertMetricsBatch(db, TODAY);
+
+    // 前のdescribeブロックで挿入した行も含むため >= 2 を検証
+    expect(count).toBeGreaterThanOrEqual(2);
 
     const metrics = await db
       .select()
@@ -365,10 +364,10 @@ describe('calculateAndUpsertMetricsBatch ベンチマーク', () => {
     expect(m2!.stars30dIncrease).toBe(300);  // 1020 - 720
   });
 
-  it('シミュレーション: バッチ版 Promise.all 化により本番D1レイテンシ相当での改善率が2%以上', async () => {
-    // バッチ版のラウンドトリップモデル:
-    //   改善前（逐次）: snap7d + snap30d + db.batch = 3 RTT
-    //   改善後（並列）: [snap7d, snap30d] + db.batch = 2 RTT
+  it('シミュレーション: todaySnaps取得の内部並列化により本番D1レイテンシ相当での改善率が2%以上', async () => {
+    // RTTモデル:
+    //   改善前: [外部 todayFetch(1RTT)] + [[snap7d, snap30d]並列(1RTT)] + [batch(1RTT)] = 3 RTT
+    //   改善後: [[today, snap7d, snap30d]全並列(1RTT)] + [batch(1RTT)] = 2 RTT
     // 本番D1のRTT中央値: ~15ms（Cloudflare公式ドキュメント参照）
     // 理論改善率: 1/3 ≈ 33%
     const LATENCY_MS = 5; // テスト時間短縮のため5msに設定（本番は~15ms）
@@ -378,46 +377,50 @@ describe('calculateAndUpsertMetricsBatch ベンチマーク', () => {
       return new Promise((resolve) => setTimeout(() => resolve(value), LATENCY_MS));
     }
 
-    // 逐次実行（改善前）: snap7d → snap30d → batch
-    async function simulateSequentialBatch(): Promise<number> {
+    // 改善前: 外部todayFetch(逐次) + [snap7d, snap30d](並列) + batch = 3RTT
+    async function simulateBefore(): Promise<number> {
       const start = Date.now();
-      await withLatency('snap7d');
-      await withLatency('snap30d');
-      await withLatency('batch-delete-insert');
+      await withLatency('todayFetch');                                          // 1RTT (外部逐次)
+      await Promise.all([withLatency('snap7d'), withLatency('snap30d')]);       // 1RTT (内部並列)
+      await withLatency('batch-delete-insert');                                 // 1RTT
       return Date.now() - start;
     }
 
-    // 並列実行（改善後）: [snap7d, snap30d] 並列 → batch
-    async function simulateParallelBatch(): Promise<number> {
+    // 改善後: [today, snap7d, snap30d](全並列) + batch = 2RTT
+    async function simulateAfter(): Promise<number> {
       const start = Date.now();
-      await Promise.all([withLatency('snap7d'), withLatency('snap30d')]);
-      await withLatency('batch-delete-insert');
+      await Promise.all([
+        withLatency('today'),
+        withLatency('snap7d'),
+        withLatency('snap30d'),
+      ]);                                                                       // 1RTT (全並列)
+      await withLatency('batch-delete-insert');                                 // 1RTT
       return Date.now() - start;
     }
 
-    let seqTotal = 0;
-    let parTotal = 0;
+    let beforeTotal = 0;
+    let afterTotal = 0;
 
     for (let r = 0; r < RUNS; r++) {
       if (r % 2 === 0) {
-        seqTotal += await simulateSequentialBatch();
-        parTotal += await simulateParallelBatch();
+        beforeTotal += await simulateBefore();
+        afterTotal += await simulateAfter();
       } else {
-        parTotal += await simulateParallelBatch();
-        seqTotal += await simulateSequentialBatch();
+        afterTotal += await simulateAfter();
+        beforeTotal += await simulateBefore();
       }
     }
 
-    const seqAvg = seqTotal / RUNS;
-    const parAvg = parTotal / RUNS;
-    const improvementPct = ((seqAvg - parAvg) / seqAvg) * 100;
+    const beforeAvg = beforeTotal / RUNS;
+    const afterAvg = afterTotal / RUNS;
+    const improvementPct = ((beforeAvg - afterAvg) / beforeAvg) * 100;
 
-    // 理論値: 3RTT逐次 → 2RTT並列 = 1/3 ≈ 33% 削減
+    // 理論値: 3RTT → 2RTT = 1/3 ≈ 33% 削減
     console.log(
-      `[バッチ版 本番D1シミュレーション] ` +
-      `逐次: ${seqAvg.toFixed(1)}ms, 並列: ${parAvg.toFixed(1)}ms, ` +
+      `[バッチ版todaySnaps並列化 本番D1シミュレーション] ` +
+      `改善前(3RTT): ${beforeAvg.toFixed(1)}ms, 改善後(2RTT): ${afterAvg.toFixed(1)}ms, ` +
       `改善率: ${improvementPct.toFixed(1)}% ` +
-      `(${LATENCY_MS}ms/RTT, ${RUNS}回平均)`
+      `(${LATENCY_MS}ms/RTT, ${RUNS}回平均, 本番D1 RTT ~15ms想定で理論改善率33%)`
     );
 
     expect(improvementPct).toBeGreaterThanOrEqual(2);

--- a/apps/backend/src/services/batch-db.ts
+++ b/apps/backend/src/services/batch-db.ts
@@ -169,21 +169,22 @@ export async function calculateAndUpsertMetrics(
 
 /**
  * 全リポジトリのメトリクスをバッチでupsertする
- * N+1クエリ問題を解消: 個別クエリO(5N)をJOINバッチ化でO(N/16 + 4)に削減
+ * N+1クエリ問題を解消: 個別クエリO(5N)をJOINバッチ化でO(N/16 + 3)に削減
+ *
+ * RTT最適化: 呼び出し元の todaySnaps 事前取得を廃止し、今日/7日前/30日前の3クエリを
+ * Promise.all で同時発行（外部1RTT + 内部2RTT = 3RTT → 内部1RTT + 1RTT = 2RTT）
  *
  * D1のパラメータ上限(100)への対応:
  * - SELECTは自己JOINを使用（INパラメータリスト不要）
  * - DELETEはcalculated_date単一条件（パラメータ1件）
  * - INSERTは6列×16行=96パラメータ以内でチャンク分割
+ *
+ * @returns 本日スナップショットが存在するリポジトリ数（0 = 対象なし）
  */
 export async function calculateAndUpsertMetricsBatch(
   db: DrizzleD1Database,
-  todaySnapshots: Array<{ repoId: number; stars: number }>,
   todayDate: string
-): Promise<void> {
-  if (todaySnapshots.length === 0) return;
-
-  const todayStarsMap = new Map(todaySnapshots.map((r) => [r.repoId, r.stars]));
+): Promise<number> {
   const sevenDaysAgoStr = getDaysAgoDate(todayDate, 7);
   const thirtyDaysAgoStr = getDaysAgoDate(todayDate, 30);
 
@@ -192,8 +193,13 @@ export async function calculateAndUpsertMetricsBatch(
   const snap7dAlias = alias(repoSnapshots, 'snap_7d');
   const snap30dAlias = alias(repoSnapshots, 'snap_30d');
 
-  // 7日前・30日前のスナップショットを並列取得（相互依存なし、1ラウンドトリップ削減）
-  const [snap7dRows, snap30dRows] = await Promise.all([
+  // 本日・7日前・30日前のスナップショットを3クエリ並列取得（1RTT）
+  // 呼び出し元での todaySnaps 事前取得（1RTT）を廃止し、3RTT → 2RTT へ削減
+  const [todayRows, snap7dRows, snap30dRows] = await Promise.all([
+    db
+      .select({ repoId: repoSnapshots.repoId, stars: repoSnapshots.stars })
+      .from(repoSnapshots)
+      .where(eq(repoSnapshots.snapshotDate, todayDate)),
     db
       .select({ repoId: snap7dAlias.repoId, stars: snap7dAlias.stars })
       .from(snapToday)
@@ -218,10 +224,13 @@ export async function calculateAndUpsertMetricsBatch(
       .where(eq(snapToday.snapshotDate, todayDate)),
   ]);
 
+  if (todayRows.length === 0) return 0;
+
+  const todayStarsMap = new Map(todayRows.map((r) => [r.repoId, r.stars]));
   const snap7dMap = new Map(snap7dRows.map((r) => [r.repoId, r.stars]));
   const snap30dMap = new Map(snap30dRows.map((r) => [r.repoId, r.stars]));
 
-  const metricsValues = todaySnapshots.map(({ repoId }) => {
+  const metricsValues = todayRows.map(({ repoId }) => {
     const currentStars = todayStarsMap.get(repoId)!;
     const stars7d = snap7dMap.get(repoId) ?? null;
     const stars30d = snap30dMap.get(repoId) ?? null;
@@ -250,6 +259,8 @@ export async function calculateAndUpsertMetricsBatch(
   );
   const batchItems = [deleteQuery, ...insertQueries] as [BatchItem<'sqlite'>, ...BatchItem<'sqlite'>[]];
   await db.batch(batchItems);
+
+  return todayRows.length;
 }
 
 /**

--- a/apps/backend/src/services/metrics-calculator.ts
+++ b/apps/backend/src/services/metrics-calculator.ts
@@ -3,11 +3,9 @@
  * HTTPエンドポイントとCronトリガーの両方から呼び出される
  */
 import type { DrizzleD1Database } from 'drizzle-orm/d1';
-import { eq } from 'drizzle-orm';
 import type { BatchMetricsResponse } from '@gh-trend-tracker/shared';
 import { getTodayISO } from '../shared/utils';
-import { repoSnapshots } from '../db/schema';
-import { calculateAndUpsertMetricsBatch } from './batch-db';
+import { calculateAndUpsertMetricsBatch, getTodaySnapshots } from './batch-db';
 
 export interface MetricsCalculateOptions {
   db: DrizzleD1Database;
@@ -24,13 +22,27 @@ export async function runMetricsCalculation(
   const startTime = Date.now();
   const todayDate = getTodayISO();
 
-  // 本日のスナップショットがあるリポジトリID・スター数を一括取得（初回クエリでstarsも取得し後続クエリを削減）
-  const todaySnaps = await db
-    .select({ repoId: repoSnapshots.repoId, stars: repoSnapshots.stars })
-    .from(repoSnapshots)
-    .where(eq(repoSnapshots.snapshotDate, todayDate));
+  let success = 0;
+  const skipped = 0;
+  let errors = 0;
+  let total = 0;
 
-  if (todaySnaps.length === 0) {
+  try {
+    // todaySnaps取得をcalculateAndUpsertMetricsBatch内で7d/30dと並列実行（3RTT→2RTT）
+    success = await calculateAndUpsertMetricsBatch(db, todayDate);
+    total = success;
+  } catch (error) {
+    // エラー時のみ件数を問い合わせて正確な total/errors を設定（成功パスにRTT影響なし）
+    const snaps = await getTodaySnapshots(db, todayDate).catch(() => []);
+    total = snaps.length;
+    errors = snaps.length || 1;
+    console.error(
+      `バッチメトリクス計算エラー: ${error instanceof Error ? error.message : error}`,
+      error instanceof Error ? error.stack : undefined
+    );
+  }
+
+  if (total === 0 && errors === 0) {
     return {
       message: 'No repositories with snapshots for today',
       summary: {
@@ -44,26 +56,10 @@ export async function runMetricsCalculation(
     };
   }
 
-  let success = 0;
-  const skipped = 0;
-  let errors = 0;
-
-  try {
-    // JOINバッチ化でN+1クエリ問題を解消（O(5N)クエリ → O(N/16+4)クエリ）
-    await calculateAndUpsertMetricsBatch(db, todaySnaps, todayDate);
-    success = todaySnaps.length;
-  } catch (error) {
-    errors = todaySnaps.length;
-    console.error(
-      `バッチメトリクス計算エラー: ${error instanceof Error ? error.message : error}`,
-      error instanceof Error ? error.stack : undefined
-    );
-  }
-
   return {
     message: 'Metrics calculation completed',
     summary: {
-      total: todaySnaps.length,
+      total,
       success,
       skipped,
       errors,

--- a/apps/backend/test/perf-batch-collector-metrics.bench.spec.ts
+++ b/apps/backend/test/perf-batch-collector-metrics.bench.spec.ts
@@ -11,13 +11,13 @@
  *
  * コレクトフロー D1ラウンドトリップ比較（N=50リポジトリ）:
  *   OLD: 1(getAll) + N(upsert) + N(snapshot) + N×4(per-repo metrics) = 6N+1 = 301 RTT
- *   NEW: 1(getAll) + N(upsert) + N(snapshot) + 1(getTodaySnaps) + 2(batch metrics) = 2N+4 = 104 RTT
- *   → D1合計: 301×4ms=1204ms → 104×4ms=416ms（改善率65.4%）
+ *   NEW: 1(getAll) + N(upsert) + N(snapshot) + [today+7d+30d並列](1RTT) + 1(batch) = 2N+3 = 103 RTT
+ *   → D1合計: 301×4ms=1204ms → 103×4ms=412ms（改善率65.8%）
  */
 import { env } from 'cloudflare:test';
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import { drizzle } from 'drizzle-orm/d1';
-import { calculateAndUpsertMetrics, calculateAndUpsertMetricsBatch, getTodaySnapshots } from '../src/services/batch-db';
+import { calculateAndUpsertMetrics, calculateAndUpsertMetricsBatch } from '../src/services/batch-db';
 
 // テスト対象リポジトリ数
 const N_REPOS = 50;
@@ -28,12 +28,12 @@ const PROD_D1_LATENCY_MS = 4;
 // コレクトフロー内の D1 ラウンドトリップ数
 // 共通処理: 1(getAll) + N(upsert) + N(snapshot) = 2N+1 RTT
 // OLD メトリクス: N×4 RTT（SELECT today + Promise.all[7d,30d] + DELETE + INSERT）
-// NEW メトリクス: 1(getTodaySnaps) + 2 RTT（Promise.all[JOIN 7d,30d] + db.batch）
+// NEW メトリクス: 2 RTT（[today+7d+30d]全並列 + db.batch）
 const SHARED_D1_RTTS = 2 * N_REPOS + 1;       // 101 RTT
 const OLD_METRICS_RTTS = 4 * N_REPOS;          // 200 RTT
-const NEW_METRICS_RTTS = 3;                     // 3 RTT（getTodaySnaps + バッチ処理）
+const NEW_METRICS_RTTS = 2;                     // 2 RTT（today/7d/30d並列1RTT + バッチ1RTT）
 const OLD_TOTAL_D1_RTTS = SHARED_D1_RTTS + OLD_METRICS_RTTS; // 301 RTT
-const NEW_TOTAL_D1_RTTS = SHARED_D1_RTTS + NEW_METRICS_RTTS; // 104 RTT
+const NEW_TOTAL_D1_RTTS = SHARED_D1_RTTS + NEW_METRICS_RTTS; // 103 RTT
 
 // Drizzle loggerでクエリ数をカウントするDBを作成
 function createCountingDb(d1: D1Database) {
@@ -148,11 +148,10 @@ describe('バッチコレクター メトリクスバッチ化 ベンチマー�
       }
       const oldMetricsQueryCount = getOldCount();
 
-      // NEW: getTodaySnapshots → calculateAndUpsertMetricsBatch（バッチ処理）
-      // getTodaySnapshotsによりonConflictDoNothing後のDB実値を使用し整合性を担保
+      // NEW: calculateAndUpsertMetricsBatch（today/7d/30d並列取得 + バッチ処理）
+      // today取得を内部で7d/30dと並列化: 3RTT → 2RTT
       await env.DB.prepare('DELETE FROM metrics_daily').run();
-      const todaySnaps = await getTodaySnapshots(newDb, today);
-      await calculateAndUpsertMetricsBatch(newDb, todaySnaps, today);
+      await calculateAndUpsertMetricsBatch(newDb, today);
       const newMetricsQueryCount = getNewCount();
 
       // 結果が正しく計算されていることを確認
@@ -171,6 +170,7 @@ describe('バッチコレクター メトリクスバッチ化 ベンチマー�
       console.log(`リポジトリ数: ${N_REPOS}`);
       console.log(`メトリクス計算クエリ数: OLD=${oldMetricsQueryCount}, NEW=${newMetricsQueryCount}`);
       console.log(`  ※ NEWのdb.batch()はDrizzle loggerを経由しないため、DELETE+INSERTはカウント外`);
+      console.log(`  ※ NEWのSELECTクエリ数: today+7d+30d 3件（Promise.all並列 = 1RTT）`);
       console.log(`全コレクトフロー D1 RTT数: OLD=${OLD_TOTAL_D1_RTTS}, NEW=${NEW_TOTAL_D1_RTTS}`);
       console.log(
         `推定本番実行時間（D1部分）: OLD=${oldEstimatedMs}ms → NEW=${newEstimatedMs}ms` +


### PR DESCRIPTION
## 概要

`calculateAndUpsertMetricsBatch` の todaySnaps 取得を関数内部に取り込み、7日前・30日前クエリと同一の `Promise.all` で並列実行する。

### 改善内容

| | 変更前 | 変更後 |
|---|---|---|
| RTT 構成 | 外部 todayFetch (1RTT) → [7d, 30d]並列 (1RTT) → db.batch (1RTT) | [today, 7d, 30d]全並列 (1RTT) → db.batch (1RTT) |
| RTT 数 | 3 RTT | 2 RTT |
| D1 推定時間 (~15ms/RTT) | ~45ms | ~30ms |
| 改善率 | — | **33%** |

**並列化の根拠**: `SELECT today`・`SELECT 7d`・`SELECT 30d` はいずれも互いに独立しており、`todayDate` はリクエスト時点で確定しているため、3クエリを同時発行可能。

### 既存 open PR との重複回避

- PR #191: `getRepositoryDetail` の並列化 → **対象外**
- PR #189: `trends-daily` のカウント・データクエリ並列化 → **対象外**
- 本 PR: `calculateAndUpsertMetricsBatch` 内 todaySnaps 並列化 → **上記 PR と重複なし**

### 変更ファイル

- **`batch-db.ts`**: シグネチャ `(db, todaySnapshots, todayDate)` → `(db, todayDate)` に変更、today クエリを Promise.all に追加、処理件数を `number` で返却
- **`metrics-calculator.ts`**: todaySnaps 事前取得を削除、戻り値でカウント取得
- **`batch-collector.ts`**: `getTodaySnapshots` 呼び出しを削除、戻り値でカウント取得
- **`batch-db.bench.test.ts`**: 新シグネチャ対応・シミュレーションモデル更新
- **`perf-batch-collector-metrics.bench.spec.ts`**: `NEW_METRICS_RTTS` を 3→2 に修正

## ベンチマーク結果

本番 D1 RTT 中央値 ~15ms を模倣したシミュレーション（5ms/RTT × 4 回平均）:

```
改善前 (3RTT: 外部todayFetch + [7d,30d]並列 + batch): 15.8ms
改善後 (2RTT: [today,7d,30d]全並列 + batch):         11.0ms
改善率: 30.2%（閾値 2% を大幅超過）
```

本番環境推定（D1 RTT ~15ms、[Cloudflare公式ドキュメント参照](https://developers.cloudflare.com/d1/platform/pricing/#metrics)）:
```
改善前: 3 × 15ms = 45ms
改善後: 2 × 15ms = 30ms（15ms 短縮、33% 削減）
```

collect フロー全体（N=50 リポジトリ、D1 RTT 4ms 想定）:
```
改善前: 301 RTT × 4ms = 1204ms
改善後: 103 RTT × 4ms =  412ms（65.8% 改善）
```

## テスト

```
Test Files  33 passed (33)
      Tests  201 passed (201)
```

lint・型チェックとも問題なし。

https://claude.ai/code/session_01XkUqpyBbfULMEPGNxTgxyQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkUqpyBbfULMEPGNxTgxyQ)_