### PR TITLE
feat(ci): 月次D1リストアテストworkflowを追加 (#155)

### DIFF
--- a/.github/workflows/restore-test.yml
+++ b/.github/workflows/restore-test.yml
@@ -14,6 +14,11 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+# GitHub Issue自動起票に必要な書き込み権限
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   restore-test:
     name: R2バックアップ → dev DB リストアテスト
@@ -44,7 +49,7 @@ jobs:
             "s3://gh-trends-backups/" \
             --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com" \
             --region auto \
-            | sort | tail -n1 | awk '{print $4}')
+            | grep "gh-trends-db_" | sort | tail -n1 | awk '{print $4}')
           if [ -z "${LATEST}" ]; then
             echo "エラー: R2 バケットにバックアップが見つかりません" >&2
             exit 1

--- a/.github/workflows/restore-test.yml
+++ b/.github/workflows/restore-test.yml
@@ -1,0 +1,153 @@
+name: Monthly D1 Restore Test
+
+on:
+  # 毎月1日 UTC 03:00 に実行（日本時間 12:00 PM）
+  # バックアップ取得（UTC 02:00）の1時間後に実行
+  schedule:
+    - cron: '0 3 1 * *'
+
+  # 手動実行を許可（動作確認用）
+  workflow_dispatch:
+
+# 同じワークフローの同時実行を防止
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  restore-test:
+    name: R2バックアップ → dev DB リストアテスト
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # R2 バケットから最新バックアップファイル名を取得
+      - name: Find latest backup in R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_BACKUP_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_BACKUP_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          LATEST=$(aws s3 ls \
+            "s3://gh-trends-backups/" \
+            --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+            --region auto \
+            | sort | tail -n1 | awk '{print $4}')
+          if [ -z "${LATEST}" ]; then
+            echo "エラー: R2 バケットにバックアップが見つかりません" >&2
+            exit 1
+          fi
+          echo "最新バックアップ: ${LATEST}"
+          echo "LATEST_BACKUP=${LATEST}" >> "$GITHUB_ENV"
+
+      # R2 から最新バックアップをダウンロード
+      - name: Download latest backup from R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_BACKUP_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_BACKUP_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          aws s3 cp \
+            "s3://gh-trends-backups/${{ env.LATEST_BACKUP }}" \
+            "/tmp/${{ env.LATEST_BACKUP }}" \
+            --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+            --region auto
+
+      - name: Decompress backup
+        run: |
+          gunzip "/tmp/${{ env.LATEST_BACKUP }}"
+          SQL_FILE="${{ env.LATEST_BACKUP }}"
+          SQL_FILE="${SQL_FILE%.gz}"
+          echo "SQL_FILE=${SQL_FILE}" >> "$GITHUB_ENV"
+          echo "解凍後ファイル: ${SQL_FILE} ($(du -sh /tmp/${SQL_FILE} | cut -f1))"
+
+      # dev DB を初期化（全テーブル削除）してリストア前の状態をクリーンにする
+      # ⚠️ この操作により gh-trends-db-dev のデータは全て失われます
+      - name: Initialize dev DB (全テーブル削除)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: |
+          cat > /tmp/drop-tables.sql << 'EOF'
+          DROP TABLE IF EXISTS ranking_weekly;
+          DROP TABLE IF EXISTS metrics_daily;
+          DROP TABLE IF EXISTS repo_snapshots;
+          DROP TABLE IF EXISTS repositories;
+          DROP TABLE IF EXISTS languages;
+          DROP TABLE IF EXISTS __drizzle_migrations;
+          DROP TABLE IF EXISTS d1_migrations;
+          EOF
+          npx wrangler d1 execute gh-trends-db-dev \
+            --env development \
+            --remote \
+            --file=/tmp/drop-tables.sql \
+            --json
+          echo "dev DB 初期化完了"
+
+      # バックアップ SQL を dev DB に適用
+      - name: Restore backup to dev DB
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: |
+          npx wrangler d1 execute gh-trends-db-dev \
+            --env development \
+            --remote \
+            --file="/tmp/${{ env.SQL_FILE }}" \
+            --json
+          echo "リストア完了"
+
+      # 整合性チェックスクリプトを実行してリストアの成功を検証
+      - name: Run DB integrity check
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: npm run db:check -- --remote --env development
+
+      # 失敗時は GitHub Issue を自動起票して通知
+      - name: 失敗時のGitHub Issue自動起票
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const date = new Date().toISOString().slice(0, 10);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `🚨 月次リストアテスト失敗 (${date})`,
+              body: [
+                '## 月次リストアテスト失敗',
+                '',
+                `**実行日時**: ${new Date().toISOString()}`,
+                `**Workflowログ**: [実行 #${context.runNumber}](${runUrl})`,
+                '',
+                '## 対応手順',
+                '',
+                '1. 上記 Workflow ログで失敗したステップを特定する',
+                '2. [障害対応Runbook](docs/プロセス/障害対応Runbook.md) の「バックアップリストア失敗」セクションを参照する',
+                '3. 手動で `workflow_dispatch` から再実行して確認する',
+                '',
+                '## 注意',
+                '',
+                '> ⚠️ リストアテスト実行中は `gh-trends-db-dev` が初期化されます。',
+                '> 開発作業に影響が出ていないか確認してください。',
+                '> 必要な場合は `npm run db:migrate:dev:remote` でマイグレーションを再適用してください。',
+              ].join('\n'),
+              labels: ['bug', 'priority: high'],
+            });

--- a/docs/プロセス/GitHubActions設定.md
+++ b/docs/プロセス/GitHubActions設定.md
@@ -344,6 +344,54 @@ GitHub Actionsのログは90日間保持されます。重要なデータは別�
 
 ---
 
+## 月次リストアテスト（restore-test.yml）
+
+`.github/workflows/restore-test.yml` は毎月1日 UTC 03:00 に R2 バックアップから dev DB へのリストアを自動検証します。
+
+> ⚠️ **重要**: リストアテスト実行中は `gh-trends-db-dev`（開発用D1）の全データが**初期化されます**。
+> テスト実行中に開発作業を行っている場合、ローカルのデータが失われる可能性があります。
+> テスト完了後に dev DB が必要な場合は `npm run db:migrate:dev:remote` で再構築してください。
+
+### リストアテストフロー
+
+```
+毎月1日 UTC 03:00（バックアップ取得の1時間後）
+  └─ restore-test ジョブ
+       ├─ R2 から最新バックアップを検索・ダウンロード
+       ├─ gz 解凍
+       ├─ dev DB を初期化（全テーブル DROP）
+       ├─ バックアップ SQL を dev DB に適用（リストア）
+       ├─ 整合性チェックスクリプトを実行（npm run db:check）
+       └─ 失敗時: GitHub Issue を自動起票
+```
+
+### 必要なシークレット
+
+リストアテストでは以下のシークレットを使用します（バックアップと同じものを流用）：
+
+| シークレット名 | 用途 |
+| --- | --- |
+| `R2_BACKUP_ACCESS_KEY_ID` | R2 からのダウンロード |
+| `R2_BACKUP_SECRET_ACCESS_KEY` | R2 からのダウンロード |
+| `CLOUDFLARE_API_TOKEN` | dev D1 への書き込み |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare API |
+
+### 手動実行でテスト
+
+1. GitHub リポジトリの **"Actions"** タブを開く
+2. 左サイドバーの **"Monthly D1 Restore Test"** をクリック
+3. **"Run workflow"** → **"Run workflow"** をクリック
+4. 全ステップが緑になることを確認
+5. 失敗した場合は自動的に GitHub Issue が起票されます
+
+### 失敗時の対応
+
+- Workflow ログで失敗したステップを確認する
+- [障害対応Runbook](./障害対応Runbook.md) の「バックアップリストア失敗」セクションを参照する
+- 手動で `workflow_dispatch` から再実行して確認する
+
+---
+
 ## 自動デプロイ（deploy.yml）
 
 `.github/workflows/deploy.yml` は `main` ブランチへの push 時または手動トリガーで自動デプロイを実行します。

--- a/docs/基本/セットアップガイド.md
+++ b/docs/基本/セットアップガイド.md
@@ -307,6 +307,18 @@ Cloudflare Pagesへのデプロイ手順は別途 [Cloudflare Pages連携ガイ�
 - [開発プロセス](../プロセス/開発プロセス.md) - 開発フロー・品質基準
 - [CLAUDE.md](../CLAUDE.md) - AI開発支援用ガイド
 
+## ⚠️ 開発用DB（gh-trends-db-dev）に関する注意事項
+
+### 月次リストアテスト中のデータ初期化
+
+毎月1日 UTC 03:00（日本時間 12:00）に `.github/workflows/restore-test.yml` が自動実行されます。このワークフローは本番DBバックアップのリストア手順を検証するため、**開発用D1（gh-trends-db-dev）のデータを一時的に全削除**します。
+
+- **影響範囲**: `gh-trends-db-dev`（リモート）のみ。ローカルDBには影響なし
+- **所要時間**: 約5〜10分
+- **手動実行**: Actions タブ > Monthly D1 Restore Test > Run workflow
+
+リストアテスト中に開発用リモートDBを参照する場合、データが存在しないか破損した状態になる可能性があります。テスト完了後にデータが必要な場合は `npm run db:migrate:dev:remote` でマイグレーションを再適用してください。
+
 ## よくある質問（FAQ）
 
 ### Q: ローカルDBとリモートDBの使い分けは？


### PR DESCRIPTION
## Summary

- `.github/workflows/restore-test.yml` を新規追加（Issue #155 の受け入れ条件をすべて満たす）
- `docs/プロセス/GitHubActions設定.md` にリストアテストの説明と dev DB 破壊の警告を追記

## Changes

### `.github/workflows/restore-test.yml`（新規）

- **cron**: 毎月1日 UTC 03:00（バックアップ取得の1時間後）に自動実行
- **workflow_dispatch**: 手動実行対応
- **concurrency**: 同時実行を防止（`cancel-in-progress: false`）
- ステップ構成:
  1. R2 から最新バックアップを検索・ダウンロード（バックアップ未検出時はエラー終了）
  2. gz 解凍
  3. dev DB を初期化（全テーブル DROP）— `gh-trends-db-dev` を一旦クリーンな状態に
  4. バックアップ SQL を dev DB にリストア（`wrangler d1 execute --file`）
  5. 整合性チェックスクリプトを実行（`npm run db:check -- --remote --env development`）
  6. 失敗時は `actions/github-script` で GitHub Issue を自動起票

### `docs/プロセス/GitHubActions設定.md`（更新）

- 月次リストアテストのフロー・必要なシークレット・手動実行手順を追記
- **dev DB 破壊の警告**（⚠️）を明示

## Test plan

- [ ] `workflow_dispatch` で手動実行し、全ステップが通過することを確認
- [ ] R2 バケットに最新バックアップが存在することを前提に動作検証
- [ ] 意図的に失敗させて GitHub Issue が自動起票されることを確認

## 受け入れ条件チェック

- [x] `.github/workflows/restore-test.yml` を追加（cron: 毎月1日 UTC 03:00）
- [x] R2 から最新バックアップを取得
- [x] 取得した SQL を `gh-trends-db-dev` に適用（適用前に dev DB を初期化）
- [x] 適用後、整合性チェックスクリプト（`npm run db:check`）を実行
- [x] 失敗時は GitHub Issue を自動起票
- [x] `workflow_dispatch` で手動実行も可能
- [x] リストアテスト中は dev DB が破壊されることを開発者に明示（ドキュメント記載）

Closes #155

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgSzve5fDcXHuMnVNCxxRP)_