### PR TITLE
feat(ci): 月次D1リストアテストworkflow追加 (#155)

### DIFF
--- a/.github/workflows/restore-test.yml
+++ b/.github/workflows/restore-test.yml
@@ -1,0 +1,142 @@
+name: Monthly D1 Restore Test
+
+on:
+  # 毎月1日 UTC 03:00 に実行（日次バックアップ取得の1時間後）
+  schedule:
+    - cron: '0 3 1 * *'
+
+  # 手動実行を許可（動作確認用）
+  workflow_dispatch:
+
+# 排他実行（リストアテストは同時実行不可）
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  restore-test:
+    name: R2バックアップ → dev DB リストアテスト
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write  # 失敗時の GitHub Issue 自動起票に必要
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # R2 バケットから最新バックアップを検索・ダウンロード
+      - name: R2 から最新バックアップを取得
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_BACKUP_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_BACKUP_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          LATEST=$(aws s3 ls \
+            "s3://gh-trends-backups/" \
+            --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+            --region auto \
+            | grep "gh-trends-db_" | sort | tail -n1 | awk '{print $4}')
+          if [ -z "${LATEST}" ]; then
+            echo "::error::R2 バケットにバックアップファイルが見つかりません（gh-trends-db_*.sql.gz）"
+            exit 1
+          fi
+          echo "最新バックアップ: ${LATEST}"
+          echo "BACKUP_FILENAME=${LATEST}" >> "$GITHUB_ENV"
+          aws s3 cp \
+            "s3://gh-trends-backups/${LATEST}" \
+            "/tmp/${LATEST}" \
+            --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+            --region auto
+
+      - name: バックアップファイルを解凍
+        run: |
+          gunzip "/tmp/${{ env.BACKUP_FILENAME }}"
+          echo "SQL_FILE=${BACKUP_FILENAME%.gz}" >> "$GITHUB_ENV"
+
+      # ⚠️ この操作で gh-trends-db-dev のデータは全て失われます
+      - name: dev DB を初期化（全テーブル削除）
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: |
+          cat > /tmp/reset-dev-db.sql << 'RESET_SQL'
+          DROP TABLE IF EXISTS ranking_weekly;
+          DROP TABLE IF EXISTS metrics_daily;
+          DROP TABLE IF EXISTS repo_snapshots;
+          DROP TABLE IF EXISTS users;
+          DROP TABLE IF EXISTS repositories;
+          DROP TABLE IF EXISTS languages;
+          DROP TABLE IF EXISTS __drizzle_migrations;
+          DROP TABLE IF EXISTS d1_migrations;
+          RESET_SQL
+          echo "dev DB（gh-trends-db-dev）を初期化します..."
+          npx wrangler d1 execute gh-trends-db-dev \
+            --env development \
+            --remote \
+            --file /tmp/reset-dev-db.sql
+          echo "dev DB 初期化完了"
+
+      - name: バックアップ SQL を dev DB にリストア
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: |
+          echo "リストア中: ${{ env.SQL_FILE }}"
+          npx wrangler d1 execute gh-trends-db-dev \
+            --env development \
+            --remote \
+            --file "/tmp/${{ env.SQL_FILE }}"
+          echo "リストア完了"
+
+      # --restore フラグで鮮度チェック（直近24時間以内）をスキップし、データ存在確認のみ行う
+      - name: 整合性チェックを実行
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: npm run db:check -- --remote --env development --restore
+
+      # 失敗時は GitHub Issue を自動起票して通知
+      - name: 失敗時 GitHub Issue 自動起票
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const date = new Date().toISOString().slice(0, 10);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `🚨 月次リストアテスト失敗 (${date})`,
+              body: [
+                '## 月次リストアテストが失敗しました',
+                '',
+                `**実行日時**: ${new Date().toISOString()}`,
+                `**ワークフロー実行**: [Run #${context.runNumber}](${runUrl})`,
+                '',
+                '## 対応手順',
+                '',
+                '1. 上記リンクからワークフロー実行ログを確認し、失敗したステップを特定する',
+                '2. [障害対応Runbook](docs/プロセス/障害対応Runbook.md) の「DB障害」セクションを参照する',
+                '3. R2 バケット（`gh-trends-backups`）にバックアップが存在するか確認する',
+                '4. dev DB の状態を手動確認:',
+                '   ```bash',
+                '   cd apps/backend && npm run db:check -- --remote --env development',
+                '   ```',
+                '5. 必要であれば `npm run db:migrate:dev:remote` で dev DB を再構築する',
+              ].join('\n'),
+              labels: ['bug'],
+            });

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ npm run dev:frontend # Web: http://localhost:4321
 
 詳細は [ロードマップ](./docs/基本/ロードマップ.md) を参照してください。
 
+## 運用上の注意
+
+### 月次リストアテスト中の開発用 DB について
+
+毎月1日 UTC 03:00 に [月次リストアテスト](./.github/workflows/restore-test.yml) が自動実行されます。
+
+> **⚠️ 警告**: このワークフロー実行中は **開発用 D1 データベース（`gh-trends-db-dev`）が初期化され、本番バックアップの内容で上書きされます。**
+> 実行後に dev DB を元の状態に戻すには `npm run db:migrate:dev:remote` を実行してください。
+> 手動実行する場合は他の開発者への周知を忘れずに。
+
 ## コスト
 
 完全無料で運用可能（Cloudflare Free枠内）：

--- a/apps/backend/scripts/check-db-integrity.ts
+++ b/apps/backend/scripts/check-db-integrity.ts
@@ -13,6 +13,7 @@
  *   npm run db:check                        # ローカルSQLiteを使用
  *   npm run db:check -- --remote            # リモートD1を使用（本番）
  *   npm run db:check -- --env development   # 開発用D1を使用
+ *   npm run db:check -- --restore           # リストアモード（鮮度チェックをスキップ）
  *
  * 終了コード:
  *   0: 全チェック通過
@@ -29,6 +30,7 @@ interface CheckResult {
 
 const args = process.argv.slice(2);
 const isRemote = args.includes('--remote');
+const isRestoreMode = args.includes('--restore');
 const envArg = args.find((a) => a.startsWith('--env'));
 const env = envArg ? envArg.split('=')[1] ?? args[args.indexOf(envArg) + 1] : 'development';
 
@@ -82,22 +84,33 @@ try {
   checks.push({ name: 'repo_snapshots: 行数 > 0', passed: false, message: String(err) });
 }
 
-// 3. metrics_daily の最新レコードが直近24時間以内
+// 3. metrics_daily の確認（リストアモード: データ存在確認のみ、通常モード: 直近24時間以内）
+// リストアモードでは古いバックアップデータを扱うため鮮度チェックをスキップする
 try {
-  const result = query(
-    `SELECT MAX(calculated_date) as latest FROM metrics_daily`
-  );
+  const result = query(`SELECT MAX(calculated_date) as latest FROM metrics_daily`);
   const latest = result.results?.[0]?.latest as string | undefined;
-  const hasRecent = latest !== undefined && latest !== null && latest >= threshold.slice(0, 10);
-  checks.push({
-    name: 'metrics_daily: 最新レコードが直近24時間以内',
-    passed: hasRecent,
-    message: hasRecent
-      ? `最新レコード: ${latest}`
-      : `最新レコード(${latest ?? 'なし'})が24時間以上前です（閾値: ${threshold.slice(0, 10)}）`,
-  });
+  if (isRestoreMode) {
+    const hasData = latest !== undefined && latest !== null;
+    checks.push({
+      name: 'metrics_daily: データ存在確認（リストアモード）',
+      passed: hasData,
+      message: hasData ? `最新レコード: ${latest}` : 'metrics_dailyにデータがありません',
+    });
+  } else {
+    const hasRecent = latest !== undefined && latest !== null && latest >= threshold.slice(0, 10);
+    checks.push({
+      name: 'metrics_daily: 最新レコードが直近24時間以内',
+      passed: hasRecent,
+      message: hasRecent
+        ? `最新レコード: ${latest}`
+        : `最新レコード(${latest ?? 'なし'})が24時間以上前です（閾値: ${threshold.slice(0, 10)}）`,
+    });
+  }
 } catch (err) {
-  checks.push({ name: 'metrics_daily: 最新レコードが直近24時間以内', passed: false, message: String(err) });
+  const checkName = isRestoreMode
+    ? 'metrics_daily: データ存在確認（リストアモード）'
+    : 'metrics_daily: 最新レコードが直近24時間以内';
+  checks.push({ name: checkName, passed: false, message: String(err) });
 }
 
 // 4. ranking_weekly の行数確認

--- a/docs/プロセス/GitHubActions設定.md
+++ b/docs/プロセス/GitHubActions設定.md
@@ -411,3 +411,60 @@ npx wrangler pages project create gh-trend-tracker-frontend
 - GitHub Actions の **Actions** タブでログを確認
 - `deploy-backend` または `deploy-frontend` ジョブが赤くなっていれば失敗
 - `ci-check` が失敗している場合は lint/テスト/ビルドエラーを先に修正する
+
+---
+
+## 月次リストアテスト（restore-test.yml）
+
+`.github/workflows/restore-test.yml` は毎月1日 UTC 03:00（日本時間 12:00）に R2 バックアップを開発用 D1 DB へリストアし、復旧手順が機能することを自動検証します。
+
+> **⚠️ 注意**: このワークフローは `gh-trends-db-dev`（開発用 D1）の全テーブルを削除してからリストアします。
+> 実行中は開発用 DB が一時的に破壊状態になります。
+> 実行後に dev DB を再構築するには `npm run db:migrate:dev:remote` を実行してください。
+
+### フロー
+
+```
+毎月1日 UTC 03:00（または手動実行）
+  └─ restore-test ジョブ
+       ├─ R2 から最新バックアップ（gh-trends-db_YYYY-MM-DD.sql.gz）を取得
+       ├─ gunzip で解凍
+       ├─ dev DB 初期化（ranking_weekly / metrics_daily / repo_snapshots / users / repositories / languages を DROP）
+       ├─ バックアップ SQL を dev DB に適用
+       ├─ 整合性チェック（npm run db:check -- --remote --env development --restore）
+       │   ※ --restore フラグで鮮度チェックをスキップ（古いバックアップデータ向け）
+       └─ 失敗時 → GitHub Issue を自動起票（ラベル: bug）
+```
+
+### 必要なシークレット
+
+`backup-d1.yml` と同じシークレットを使用します（追加設定不要）。
+
+| シークレット名 | 用途 |
+| --- | --- |
+| `R2_BACKUP_ACCESS_KEY_ID` | R2 バケットからの読み取り |
+| `R2_BACKUP_SECRET_ACCESS_KEY` | R2 バケットからの読み取り |
+| `CLOUDFLARE_API_TOKEN` | dev D1 への書き込み |
+| `CLOUDFLARE_ACCOUNT_ID` | R2 エンドポイント URL の構成 |
+
+### `--restore` フラグについて
+
+`check-db-integrity.ts` の `--restore` フラグを付けると、タイムスタンプベースの鮮度チェック（直近24時間以内）をスキップし、データが存在することのみを確認します。バックアップは古いデータを含むため、通常モードでは必ずタイムスタンプチェックが失敗します。
+
+### 手動実行手順
+
+1. GitHub リポジトリの **"Actions"** タブを開く
+2. 左サイドバーの **"Monthly D1 Restore Test"** をクリック
+3. **"Run workflow"** → **"Run workflow"** をクリック
+4. `整合性チェックを実行` ステップが ✅ で完了することを確認
+
+### 失敗時の対応
+
+自動起票された Issue を確認し、[障害対応Runbook](./障害対応Runbook.md) を参照してください。
+主な原因と対処：
+
+| 原因 | 対処 |
+| --- | --- |
+| R2 にバックアップが存在しない | `backup-d1.yml` の実行履歴を確認 |
+| dev D1 への接続失敗 | `CLOUDFLARE_API_TOKEN` の権限・有効期限を確認 |
+| 整合性チェック失敗 | バックアップ SQL ファイルのデータ品質を確認 |


### PR DESCRIPTION
## Summary

- `.github/workflows/restore-test.yml` を追加（cron: 毎月1日 UTC 03:00）
- R2 から最新バックアップを取得し dev D1 へリストア後、整合性チェックを実行
- `check-db-integrity.ts` に `--restore` フラグを追加（バックアップデータ向けの鮮度チェックスキップ）
- 失敗時は GitHub Issue を自動起票（ラベル: `bug`）
- `workflow_dispatch` による手動実行に対応
- README.md に dev DB 破壊の警告を追記
- `docs/プロセス/GitHubActions設定.md` に運用手順を追記

## 既存 PR との差別化

Issue #155 には既に複数の PR が存在しますが、多くは `metrics_daily: 最新レコードが直近24時間以内` チェックが**バックアップデータでは必ず失敗する**問題を抱えています。本 PR では `--restore` フラグを `check-db-integrity.ts` に追加し、リストアモード時は鮮度チェックをスキップしてデータ存在確認のみを行います。

| 比較 | 他の多くの PR | 本 PR |
|---|---|---|
| `--restore` フラグ | なし（鮮度チェックが必ず失敗） | ✅ 追加済み |
| `users` テーブルの DROP | 一部のみ | ✅ 含む |
| バックアップ検索フィルタ | `sort \| tail -1` | ✅ `grep "gh-trends-db_" \| sort \| tail -n1` |
| `permissions` 設定 | トップレベル or なし | ✅ ジョブレベルで最小権限 |
| `concurrency` 設定 | ✅ | ✅ |

## Test plan

- [ ] `workflow_dispatch` で手動実行し、R2 からバックアップ取得 → dev DB へリストア → 整合性チェックが通過することを確認
- [ ] 整合性チェクが `--restore` モードで `metrics_daily: データ存在確認（リストアモード）` として通過することを確認
- [ ] 失敗ケース（バックアップなし等）で GitHub Issue が自動起票されることを確認

## Changes

| ファイル | 変更内容 |
| --- | --- |
| `.github/workflows/restore-test.yml` | 新規追加：月次リストアテストworkflow |
| `apps/backend/scripts/check-db-integrity.ts` | `--restore` フラグを追加（鮮度チェックをスキップ） |
| `README.md` | dev DB 破壊警告セクションを追加 |
| `docs/プロセス/GitHubActions設定.md` | restore-test.yml の運用ドキュメントを追加 |

Closes #155

https://claude.ai/code/session_01MtEUMuqV28TJDxEN4F4LwG

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtEUMuqV28TJDxEN4F4LwG)_