### PR TITLE
feat(ci): 月次D1リストアテストworkflowを追加 (#155)

### DIFF
--- a/.github/workflows/restore-test.yml
+++ b/.github/workflows/restore-test.yml
@@ -8,8 +8,9 @@ on:
   # 手動実行を許可（動作確認用）
   workflow_dispatch:
 
-# GitHub Issueへの書き込み権限が必要
+# checkout に contents:read、Issue起票に issues:write が必要
 permissions:
+  contents: read
   issues: write
 
 jobs:
@@ -29,6 +30,13 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: dev D1 database ID を wrangler.jsonc に注入
+        env:
+          DEV_D1_DATABASE_ID: ${{ secrets.DEV_D1_DATABASE_ID }}
+        run: |
+          # wrangler.jsonc のプレースホルダーを実際の dev D1 database ID に置換
+          sed -i "s/REPLACE_WITH_DEV_D1_DATABASE_ID/${DEV_D1_DATABASE_ID}/g" apps/backend/wrangler.jsonc
 
       - name: 最新バックアップをR2から取得
         env:

--- a/.github/workflows/restore-test.yml
+++ b/.github/workflows/restore-test.yml
@@ -1,0 +1,143 @@
+name: 月次 D1 リストアテスト
+
+on:
+  # 毎月1日 UTC 03:00 に実行（日本時間 12:00 PM）
+  schedule:
+    - cron: '0 3 1 * *'
+
+  # 手動実行を許可（動作確認用）
+  workflow_dispatch:
+
+# GitHub Issueへの書き込み権限が必要
+permissions:
+  issues: write
+
+jobs:
+  restore-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: 最新バックアップをR2から取得
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_BACKUP_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_BACKUP_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          # R2バケットから最新バックアップのファイル名を取得（日付昇順ソートで末尾が最新）
+          LATEST_KEY=$(aws s3 ls \
+            "s3://gh-trends-backups/" \
+            --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+            --region auto \
+            | sort | tail -n1 | awk '{print $4}')
+
+          if [ -z "$LATEST_KEY" ]; then
+            echo "::error::R2にバックアップが存在しません"
+            exit 1
+          fi
+
+          echo "最新バックアップ: ${LATEST_KEY}"
+          echo "BACKUP_KEY=${LATEST_KEY}" >> "$GITHUB_ENV"
+
+          aws s3 cp \
+            "s3://gh-trends-backups/${LATEST_KEY}" \
+            "/tmp/${LATEST_KEY}" \
+            --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+            --region auto
+
+      - name: バックアップを展開
+        run: |
+          gunzip "/tmp/${BACKUP_KEY}"
+          SQL_FILE="/tmp/${BACKUP_KEY%.gz}"
+          echo "SQL_FILE=${SQL_FILE}" >> "$GITHUB_ENV"
+          echo "展開完了: ${SQL_FILE} ($(wc -l < "${SQL_FILE}") 行)"
+
+      - name: dev DB を初期化（全テーブル削除）
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: |
+          # ユーザーテーブル名を取得（SQLite・Cloudflare内部テーブルを除外）
+          QUERY_RESULT=$(npx wrangler d1 execute gh-trends-db-dev \
+            --env development --remote \
+            --command "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_cf_%' AND name NOT LIKE 'd1_%'" \
+            --json)
+          TABLES=$(echo "$QUERY_RESULT" | jq -r '.[0].results[].name // empty' 2>/dev/null || true)
+
+          if [ -z "$TABLES" ]; then
+            echo "削除対象テーブルなし（空のDB）"
+          else
+            # DROP TABLE SQLを一時ファイルに書き出して一括実行
+            DROP_SQL_FILE=$(mktemp /tmp/drop-tables.XXXXXX.sql)
+            echo "PRAGMA foreign_keys = OFF;" > "$DROP_SQL_FILE"
+            for TABLE in $TABLES; do
+              echo "DROP TABLE IF EXISTS \"${TABLE}\";" >> "$DROP_SQL_FILE"
+            done
+            echo "削除対象テーブル:"
+            cat "$DROP_SQL_FILE"
+            npx wrangler d1 execute gh-trends-db-dev \
+              --env development --remote \
+              --file "$DROP_SQL_FILE"
+            rm -f "$DROP_SQL_FILE"
+            echo "全テーブル削除完了"
+          fi
+
+      - name: バックアップSQLを dev DB に適用
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: |
+          echo "適用ファイル: ${{ env.SQL_FILE }}"
+          npx wrangler d1 execute gh-trends-db-dev \
+            --env development --remote \
+            --file "${{ env.SQL_FILE }}"
+
+      - name: 整合性チェック実行
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: npm run db:check -- --remote --env development
+
+      - name: 失敗時にGitHub Issueを起票
+        if: failure()
+        uses: actions/github-script@v7
+        env:
+          BACKUP_KEY: ${{ env.BACKUP_KEY }}
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const backupKey = process.env.BACKUP_KEY || '（取得前に失敗）';
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[自動] 月次リストアテスト失敗 (${new Date().toISOString().slice(0, 10)})`,
+              body: [
+                '## 月次リストアテスト失敗',
+                '',
+                `実行日時: ${new Date().toISOString()}`,
+                `バックアップキー: ${backupKey}`,
+                `ワークフロー実行: ${runUrl}`,
+                '',
+                '### 対応が必要な事項',
+                '',
+                '- [ ] ワークフローのログを確認',
+                '- [ ] バックアップデータの整合性を確認',
+                '- [ ] リストア手順の見直し（必要に応じて）',
+              ].join('\n'),
+              labels: ['bug'],
+            });

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ npm run dev:frontend # Web: http://localhost:4321
 
 詳細は [ロードマップ](./docs/基本/ロードマップ.md) を参照してください。
 
+## ⚠️ 注意事項
+
+| 事項 | 詳細 |
+| ---- | ---- |
+| **月次リストアテスト** | 毎月1日 UTC 03:00 に `gh-trends-db-dev`（開発用D1）が初期化されます。テスト後に dev DB が必要な場合は `npm run db:migrate:dev:remote` で再構築してください。 |
+| **本番DB直接操作禁止** | `wrangler d1 execute gh-trends-db --remote` の直接実行は禁止です。スキーマ変更は必ず `schema.ts` → マイグレーション手順で行ってください。 |
+
 ## コスト
 
 完全無料で運用可能（Cloudflare Free枠内）：

--- a/docs/プロセス/GitHubActions設定.md
+++ b/docs/プロセス/GitHubActions設定.md
@@ -344,6 +344,56 @@ GitHub Actionsのログは90日間保持されます。重要なデータは別�
 
 ---
 
+## 月次 D1 リストアテスト（restore-test.yml）
+
+`.github/workflows/restore-test.yml` は毎月1日 UTC 03:00 に、R2 バックアップから dev DB へのリストアを自動検証します。
+
+> ⚠️ **注意: このワークフロー実行中は `gh-trends-db-dev`（開発用D1）が破壊されます。**
+> リストアテスト実行中は開発用 D1 データベースが初期化・上書きされるため、
+> ローカル開発や PR Preview 環境への影響が発生する可能性があります。
+> テスト後は `npm run db:migrate:dev:remote` で dev DB を再構築してください。
+
+### リストアテストフロー
+
+```
+毎月1日 UTC 03:00
+  └─ restore-test ジョブ
+       ├─ R2 ls → 最新バックアップキーを取得
+       ├─ R2 cp → /tmp/gh-trends-db_YYYY-MM-DD.sql.gz をダウンロード
+       ├─ gunzip → /tmp/gh-trends-db_YYYY-MM-DD.sql に展開
+       ├─ dev DB 初期化 → 全ユーザーテーブルを DROP
+       ├─ wrangler d1 execute --file → バックアップSQLを dev DB に適用
+       ├─ npm run db:check -- --remote --env development → 整合性チェック
+       └─ 失敗時 → GitHub Issue を自動起票
+```
+
+### 必要なシークレット
+
+リストアテストはバックアップ用シークレット（`R2_BACKUP_ACCESS_KEY_ID`、`R2_BACKUP_SECRET_ACCESS_KEY`）と、wrangler 用シークレット（`CLOUDFLARE_API_TOKEN`、`CLOUDFLARE_ACCOUNT_ID`）を使用します。追加のシークレット設定は不要です。
+
+### 手動実行でテスト
+
+1. GitHub リポジトリの **"Actions"** タブを開く
+2. 左サイドバーの **"月次 D1 リストアテスト"** をクリック
+3. **"Run workflow"** → **"Run workflow"** をクリック
+4. 実行ログで `整合性チェック実行` ステップが成功することを確認
+
+### テスト後の dev DB 再構築
+
+リストアテスト後に dev DB を開発状態に戻す場合：
+
+```bash
+cd apps/backend
+# dev DB にマイグレーションを再適用
+npm run db:migrate:dev:remote
+```
+
+### 失敗時の自動 Issue 起票
+
+整合性チェックまたはリストア処理が失敗した場合、`[自動] 月次リストアテスト失敗 (YYYY-MM-DD)` というタイトルで GitHub Issue が自動起票されます。起票された Issue のワークフロー実行リンクからログを確認し、原因を調査してください。
+
+---
+
 ## 自動デプロイ（deploy.yml）
 
 `.github/workflows/deploy.yml` は `main` ブランチへの push 時または手動トリガーで自動デプロイを実行します。


### PR DESCRIPTION
## Summary

- `.github/workflows/restore-test.yml` を新規追加（毎月1日 UTC 03:00 / `workflow_dispatch` 対応）
- R2から最新バックアップを取得 → dev DB を初期化 → SQLを適用 → 整合性チェックの一連フローを実装
- 失敗時に GitHub Issue を自動起票（`actions/github-script@v7` 使用）
- dev DB 破壊の注意事項を `README.md` および `docs/プロセス/GitHubActions設定.md` に明記

## Changes

### `.github/workflows/restore-test.yml`（新規）

| ステップ | 内容 |
| --- | --- |
| 最新バックアップをR2から取得 | `aws s3 ls` でソートし最新キーを特定、ダウンロード |
| バックアップを展開 | `gunzip` で `.sql.gz` → `.sql` に展開 |
| dev DB を初期化 | `sqlite_master` からユーザーテーブルを取得し `DROP TABLE` 一括実行 |
| バックアップSQLを dev DB に適用 | `wrangler d1 execute --file` でリストア |
| 整合性チェック実行 | `npm run db:check -- --remote --env development` |
| 失敗時にGitHub Issue起票 | `actions/github-script@v7` でIssue自動作成 |

### `docs/プロセス/GitHubActions設定.md`

- 「月次 D1 リストアテスト（restore-test.yml）」セクションを追加
- フロー図、手動実行方法、テスト後のdev DB再構築手順を記載

### `README.md`

- 「⚠️ 注意事項」セクションを追加
- 月次リストアテストによるdev DB破壊と本番DB直接操作禁止を明記

## Test plan

- [ ] `workflow_dispatch` で手動実行し、R2バックアップ取得〜整合性チェックまで成功することを確認
- [ ] 意図的に整合性チェックを失敗させ、GitHub Issueが自動起票されることを確認
- [ ] テスト後に `npm run db:migrate:dev:remote` で dev DB が再構築できることを確認

Closes #155

https://claude.ai/code/session_01RvK7QjtsqdfquvaeQy7Sg9

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvK7QjtsqdfquvaeQy7Sg9)_