### PR TITLE
feat(ci): 月次リストアテストworkflow追加 (#155)

### DIFF
--- a/.github/workflows/restore-test.yml
+++ b/.github/workflows/restore-test.yml
@@ -12,6 +12,9 @@ jobs:
   restore-test:
     name: D1 Restore Test (dev DB)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - name: Checkout repository
@@ -78,7 +81,9 @@ jobs:
         run: |
           echo "::warning::⚠️ 開発用DB (gh-trends-db-dev) を初期化します。開発中のローカルデータは失われます。"
 
-          for table in users ranking_weekly metrics_daily repo_snapshots repositories languages; do
+          # d1_migrations はwrangler d1 migrations applyが管理するメタテーブル。
+          # バックアップSQLに同テーブルのINSERTが含まれる場合、残存していると競合するため必ず DROPする。
+          for table in users ranking_weekly metrics_daily repo_snapshots repositories languages d1_migrations; do
             npx wrangler d1 execute gh-trends-db-dev \
               --env development \
               --remote \

--- a/.github/workflows/restore-test.yml
+++ b/.github/workflows/restore-test.yml
@@ -1,0 +1,145 @@
+name: Monthly Restore Test
+
+on:
+  # 毎月1日 UTC 03:00 に実行（日次バックアップ後の時間帯）
+  schedule:
+    - cron: '0 3 1 * *'
+
+  # 手動実行を許可（動作確認・緊急検証用）
+  workflow_dispatch:
+
+jobs:
+  restore-test:
+    name: D1 Restore Test (dev DB)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install AWS CLI
+        run: pip install awscli --quiet
+
+      # R2バケットから最新バックアップファイル名を取得
+      - name: Find latest backup in R2
+        id: find-backup
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_BACKUP_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_BACKUP_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          LATEST=$(aws s3 ls "s3://gh-trends-backups/" \
+            --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+            --region auto \
+            | grep -E '\.sql\.gz$' \
+            | sort | tail -n 1 | awk '{print $4}')
+
+          if [ -z "$LATEST" ]; then
+            echo "::error::R2バケットにバックアップファイルが見つかりません"
+            exit 1
+          fi
+
+          echo "backup_file=${LATEST}" >> "$GITHUB_OUTPUT"
+          echo "最新バックアップ: ${LATEST}"
+
+      # R2から最新バックアップをダウンロードして解凍
+      - name: Download and decompress backup
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_BACKUP_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_BACKUP_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          aws s3 cp \
+            "s3://gh-trends-backups/${{ steps.find-backup.outputs.backup_file }}" \
+            "/tmp/backup.sql.gz" \
+            --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+            --region auto
+
+          gunzip /tmp/backup.sql.gz
+          echo "バックアップ解凍完了: $(wc -l < /tmp/backup.sql) 行"
+
+      # ⚠️ 開発用DBを全テーブルDROPして初期化する
+      # この操作により gh-trends-db-dev の既存データはすべて失われる
+      - name: Initialize dev DB (drop all tables)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: |
+          echo "::warning::⚠️ 開発用DB (gh-trends-db-dev) を初期化します。開発中のローカルデータは失われます。"
+
+          for table in users ranking_weekly metrics_daily repo_snapshots repositories languages; do
+            npx wrangler d1 execute gh-trends-db-dev \
+              --env development \
+              --remote \
+              --command "DROP TABLE IF EXISTS ${table}" || true
+          done
+
+          echo "テーブル初期化完了"
+
+      # バックアップSQLを開発用DBに適用
+      - name: Apply backup SQL to dev DB
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: |
+          npx wrangler d1 execute gh-trends-db-dev \
+            --env development \
+            --remote \
+            --file /tmp/backup.sql
+
+          echo "バックアップ適用完了"
+
+      # 整合性チェックを実行（バックアップが古いため --allow-stale で時刻チェックをスキップ）
+      - name: Run integrity check
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: |
+          npm run db:check -- --remote --env development --allow-stale
+
+      # 失敗時はGitHub Issueを自動起票して通知
+      - name: Create GitHub Issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const date = new Date().toISOString().slice(0, 10);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[自動] 月次リストアテスト失敗 (${date})`,
+              body: [
+                '## 月次リストアテストが失敗しました',
+                '',
+                `- **実行日時**: ${new Date().toISOString()}`,
+                `- **ワークフロー実行**: [ログを確認する](${runUrl})`,
+                '',
+                '## 対応手順',
+                '',
+                '1. 上記リンクからワークフローのログを確認する',
+                '2. R2バケット `gh-trends-backups` にバックアップファイルが存在するか確認する',
+                '3. シークレット（`R2_BACKUP_ACCESS_KEY_ID` / `R2_BACKUP_SECRET_ACCESS_KEY` / `CLOUDFLARE_API_TOKEN`）が有効か確認する',
+                '4. 整合性チェックの失敗内容を確認し、バックアップSQLが正常に適用されているか確認する',
+                '',
+                '## 参考資料',
+                '',
+                '- [障害対応Runbook](../../blob/main/docs/プロセス/障害対応Runbook.md)',
+                '- [GitHub Actions設定](../../blob/main/docs/プロセス/GitHubActions設定.md)',
+              ].join('\n'),
+              labels: ['bug', 'priority: high'],
+            });

--- a/apps/backend/scripts/check-db-integrity.ts
+++ b/apps/backend/scripts/check-db-integrity.ts
@@ -10,9 +10,14 @@
  *   - repositories の主キー重複が無いこと
  *
  * 使用方法:
- *   npm run db:check                        # ローカルSQLiteを使用
- *   npm run db:check -- --remote            # リモートD1を使用（本番）
- *   npm run db:check -- --env development   # 開発用D1を使用
+ *   npm run db:check                              # ローカルSQLiteを使用
+ *   npm run db:check -- --remote                  # リモートD1を使用（本番）
+ *   npm run db:check -- --env development         # 開発用D1を使用
+ *   npm run db:check -- --remote --allow-stale    # 時刻チェックをスキップ（リストアテスト用）
+ *
+ * オプション:
+ *   --allow-stale  metrics_dailyの時刻チェックをスキップする。
+ *                  月次リストアテストのように古いバックアップを適用した場合に使用する。
  *
  * 終了コード:
  *   0: 全チェック通過
@@ -29,6 +34,8 @@ interface CheckResult {
 
 const args = process.argv.slice(2);
 const isRemote = args.includes('--remote');
+// バックアップからのリストア後など、データが古い場合に時刻チェックをスキップするフラグ
+const isAllowStale = args.includes('--allow-stale');
 const envArg = args.find((a) => a.startsWith('--env'));
 const env = envArg ? envArg.split('=')[1] ?? args[args.indexOf(envArg) + 1] : 'development';
 
@@ -82,19 +89,25 @@ try {
   checks.push({ name: 'repo_snapshots: 行数 > 0', passed: false, message: String(err) });
 }
 
-// 3. metrics_daily の最新レコードが直近24時間以内
+// 3. metrics_daily の最新レコードが直近24時間以内（--allow-stale 時はデータ存在のみ確認）
 try {
   const result = query(
     `SELECT MAX(calculated_date) as latest FROM metrics_daily`
   );
   const latest = result.results?.[0]?.latest as string | undefined;
-  const hasRecent = latest !== undefined && latest !== null && latest >= threshold.slice(0, 10);
+  const hasData = latest !== undefined && latest !== null;
+  const hasRecent = hasData && latest >= threshold.slice(0, 10);
+  // --allow-stale: リストアテスト等でデータが古い場合、時刻チェックをスキップしデータ存在のみ確認
+  const passed = isAllowStale ? hasData : hasRecent;
+  const checkName = isAllowStale
+    ? 'metrics_daily: データ存在確認（--allow-stale: 時刻チェックスキップ）'
+    : 'metrics_daily: 最新レコードが直近24時間以内';
   checks.push({
-    name: 'metrics_daily: 最新レコードが直近24時間以内',
-    passed: hasRecent,
-    message: hasRecent
+    name: checkName,
+    passed,
+    message: passed
       ? `最新レコード: ${latest}`
-      : `最新レコード(${latest ?? 'なし'})が24時間以上前です（閾値: ${threshold.slice(0, 10)}）`,
+      : `最新レコード(${latest ?? 'なし'})${isAllowStale ? 'が存在しません' : `が24時間以上前です（閾値: ${threshold.slice(0, 10)}）`}`,
   });
 } catch (err) {
   checks.push({ name: 'metrics_daily: 最新レコードが直近24時間以内', passed: false, message: String(err) });

--- a/docs/基本/開発ガイド.md
+++ b/docs/基本/開発ガイド.md
@@ -171,6 +171,16 @@ npx wrangler d1 execute gh-trends-db --command="SELECT COUNT(*) FROM repositorie
 > 誤操作リスクが高いため、通常の開発では `--local` または開発用D1（`gh-trends-db-dev`）を使用してください。
 > **本番DBへの直接スキーマ変更（`wrangler d1 execute --file=schema.sql --remote`）は禁止です。**
 
+#### ⚠️ 月次リストアテストによる開発用DB初期化について
+
+毎月1日 UTC 03:00 に `.github/workflows/restore-test.yml` が自動実行されます。
+このワークフローは **開発用DB（`gh-trends-db-dev`）の全テーブルを削除した後、本番バックアップを適用** します。
+
+- **影響範囲**: 開発用DBのリモートデータ（`--remote`）のみ。ローカルDBは影響を受けません
+- **対象DB**: `gh-trends-db-dev`（本番DB `gh-trends-db` には一切触れません）
+- **事前確認**: テスト実行前後にリモート開発DBのデータが必要な場合は、`workflow_dispatch` のタイミングに注意してください
+- **手動実行**: GitHub Actions タブから「Monthly Restore Test」を `workflow_dispatch` で手動実行できます
+
 ### その他の便利コマンド
 
 ```bash


### PR DESCRIPTION
## Summary

- `.github/workflows/restore-test.yml` を追加（毎月1日 UTC 03:00 / `workflow_dispatch`）
- R2バケット（`gh-trends-backups`）から最新バックアップを自動取得・解凍
- 開発用DB（`gh-trends-db-dev`）を全テーブルDROPして初期化後にバックアップSQLを適用
- 整合性チェックスクリプト（`db:check`）に `--allow-stale` フラグを追加し、古いバックアップ適用時の時刻チェックをスキップできるように対応
- 失敗時はGitHub Issueを自動起票（`bug` / `priority: high` ラベル付き）
- 開発ガイドに月次リストアテストによるdev DB初期化の注意事項を追記

## Changes

### `.github/workflows/restore-test.yml`（新規）

| ステップ | 内容 |
| --- | --- |
| Find latest backup in R2 | S3互換APIでバケット一覧を取得し最新 `.sql.gz` を特定 |
| Download and decompress | R2からダウンロード → `gunzip` で解凍 |
| Initialize dev DB | 全テーブルを `DROP TABLE IF EXISTS` で初期化（本番DBには触れない） |
| Apply backup SQL | `wrangler d1 execute --file` でバックアップSQLを開発用DBに適用 |
| Run integrity check | `npm run db:check -- --remote --env development --allow-stale` |
| Create GitHub Issue on failure | `actions/github-script` でIssueを自動起票 |

### `apps/backend/scripts/check-db-integrity.ts`（変更）

- `--allow-stale` フラグを追加
- `metrics_daily` の時刻チェックを `--allow-stale` 指定時はスキップし、データ存在のみ確認する

### `docs/基本/開発ガイド.md`（変更）

- 月次リストアテストによる dev DB（リモート）初期化について注意事項セクションを追加

## Test plan

- [ ] `workflow_dispatch` で「Monthly Restore Test」を手動実行し、全ステップが成功することを確認
- [ ] 失敗ケースのテスト: シークレットを一時的に無効化し、GitHub Issueが自動起票されることを確認
- [ ] `npm run db:check -- --allow-stale` のオプション動作を確認（時刻チェックがスキップされること）

## 必要なシークレット（既存と共通）

| シークレット | 用途 |
| --- | --- |
| `CLOUDFLARE_API_TOKEN` | wrangler d1 execute（開発用DB） |
| `CLOUDFLARE_ACCOUNT_ID` | R2エンドポイントURL |
| `R2_BACKUP_ACCESS_KEY_ID` | R2バケット読み取り |
| `R2_BACKUP_SECRET_ACCESS_KEY` | R2バケット読み取り |

Closes #155

---
_Generated by [Claude Code](https://claude.ai/code/session_012BQD4WmWuChcGd3kCgzKjv)_