### PR TITLE
feat(ci): 月次リストアテストworkflow整備 (#155)

### DIFF
--- a/.github/workflows/restore-test.yml
+++ b/.github/workflows/restore-test.yml
@@ -15,10 +15,17 @@ jobs:
   restore-test:
     name: Restore Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Configure dev D1 database ID
+        run: |
+          sed -i 's/REPLACE_WITH_DEV_D1_DATABASE_ID/${{ secrets.DEV_D1_DATABASE_ID }}/g' apps/backend/wrangler.jsonc
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/restore-test.yml
+++ b/.github/workflows/restore-test.yml
@@ -1,0 +1,140 @@
+name: Monthly Restore Test
+
+on:
+  # 毎月1日 UTC 03:00 に実行（日本時間 12:00 PM）
+  schedule:
+    - cron: '0 3 1 * *'
+
+  # 手動実行を許可（動作確認用）
+  workflow_dispatch:
+
+# ⚠️ このワークフロー実行中は gh-trends-db-dev (dev D1) が初期化されます。
+# 開発環境のデータが失われるため、実行タイミングに注意してください。
+
+jobs:
+  restore-test:
+    name: Restore Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Get latest backup from R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_BACKUP_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_BACKUP_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          LATEST=$(aws s3 ls \
+            "s3://gh-trends-backups/" \
+            --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+            --region auto \
+            | sort | tail -n 1 | awk '{print $4}')
+
+          if [ -z "$LATEST" ]; then
+            echo "::error::バックアップファイルがR2に見つかりません"
+            exit 1
+          fi
+
+          echo "BACKUP_FILE=${LATEST}" >> "$GITHUB_ENV"
+          echo "最新バックアップ: ${LATEST}"
+
+          aws s3 cp \
+            "s3://gh-trends-backups/${LATEST}" \
+            "/tmp/${LATEST}" \
+            --endpoint-url "https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+            --region auto
+
+      - name: Decompress backup
+        run: |
+          gunzip "/tmp/${{ env.BACKUP_FILE }}"
+          SQL_FILE="${{ env.BACKUP_FILE }}"
+          SQL_FILE="${SQL_FILE%.gz}"
+          echo "SQL_FILE=${SQL_FILE}" >> "$GITHUB_ENV"
+          echo "解凍後ファイル: ${SQL_FILE}"
+          ls -lh "/tmp/${SQL_FILE}"
+
+      - name: Reset dev DB
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: |
+          echo "dev DB (gh-trends-db-dev) のユーザーテーブルを削除中..."
+
+          TABLES=$(npx wrangler d1 execute gh-trends-db-dev \
+            --env development \
+            --remote \
+            --command "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'd1_%' AND name NOT LIKE '_cf_%'" \
+            --json 2>/dev/null | jq -r '.[0].results[].name' 2>/dev/null || true)
+
+          if [ -z "$TABLES" ]; then
+            echo "削除対象テーブルなし（空のDB）"
+          else
+            for TABLE in $TABLES; do
+              echo "DROP TABLE: ${TABLE}"
+              npx wrangler d1 execute gh-trends-db-dev \
+                --env development \
+                --remote \
+                --command "DROP TABLE IF EXISTS \"${TABLE}\"" \
+                --json > /dev/null 2>&1 || true
+            done
+            echo "全テーブルの削除完了"
+          fi
+
+      - name: Restore backup to dev DB
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: |
+          echo "バックアップをdev DBに適用中: ${{ env.SQL_FILE }}"
+          npx wrangler d1 execute gh-trends-db-dev \
+            --env development \
+            --remote \
+            --file "/tmp/${{ env.SQL_FILE }}" \
+            --json
+          echo "バックアップ適用完了"
+
+      - name: Run integrity check
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        working-directory: apps/backend
+        run: npm run db:check -- --remote --env development
+
+      - name: Create GitHub Issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const date = new Date().toISOString().slice(0, 10);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[自動] 月次リストアテスト失敗 (${date})`,
+              body: [
+                '## 月次リストアテスト失敗\n',
+                `**実行日時**: ${new Date().toISOString()}`,
+                `**ワークフロー実行**: [Run #${context.runId}](${runUrl})\n`,
+                '## 確認事項',
+                '- [ ] R2バックアップファイルの存在・整合性確認',
+                '- [ ] dev D1 (gh-trends-db-dev) の現在の状態確認',
+                '- [ ] ワークフローログの詳細確認\n',
+                '## 参考',
+                '- [障害対応Runbook](../blob/main/docs/プロセス/障害対応Runbook.md)',
+              ].join('\n'),
+              labels: ['bug', 'priority: high'],
+            });

--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ npm run dev:frontend # Web: http://localhost:4321
 
 詳細は [ロードマップ](./docs/基本/ロードマップ.md) を参照してください。
 
+## 自動化ワークフロー
+
+| ワークフロー | スケジュール | 概要 |
+| ------------ | ------------ | ---- |
+| `collect-data.yml` | 毎日 UTC 0:00 | GitHubトレンドデータ収集 |
+| `backup-d1.yml` | 毎日 UTC 2:00 | D1データベースをR2へバックアップ |
+| `restore-test.yml` | 毎月1日 UTC 3:00 | R2バックアップからのリストアテスト |
+| `deploy.yml` | mainプッシュ時 | Backend/Frontendの自動デプロイ |
+
+> ⚠️ **注意**: `restore-test.yml` の実行中は **dev D1 (gh-trends-db-dev) が初期化されます**。
+> 開発環境のデータが失われるため、実行タイミングに注意してください。
+
 ## コスト
 
 完全無料で運用可能（Cloudflare Free枠内）：

--- a/docs/プロセス/GitHubActions設定.md
+++ b/docs/プロセス/GitHubActions設定.md
@@ -411,3 +411,74 @@ npx wrangler pages project create gh-trend-tracker-frontend
 - GitHub Actions の **Actions** タブでログを確認
 - `deploy-backend` または `deploy-frontend` ジョブが赤くなっていれば失敗
 - `ci-check` が失敗している場合は lint/テスト/ビルドエラーを先に修正する
+
+---
+
+## 月次リストアテスト（restore-test.yml）
+
+`.github/workflows/restore-test.yml` は毎月1日 UTC 03:00（日本時間 12:00）に R2 バックアップからのリストアテストを実行します。
+
+### リストアテストフロー
+
+```
+毎月1日 UTC 03:00
+  └─ restore-test ジョブ
+       ├─ R2 から最新バックアップを取得（.sql.gz）
+       ├─ gzip 解凍
+       ├─ dev D1 (gh-trends-db-dev) を初期化（全ユーザーテーブルをDROP）
+       ├─ バックアップSQLを dev D1 に適用
+       ├─ 整合性チェック（npm run db:check -- --remote --env development）
+       └─ 失敗時: GitHub Issue を自動起票
+```
+
+### ⚠️ 重要: dev DB の破壊について
+
+**リストアテスト実行中は `gh-trends-db-dev`（開発用 D1）が完全に初期化されます。**
+
+- リストアテスト実行中は開発環境のデータが失われます
+- ローカル開発中にリストアテストが走った場合、dev D1 への接続は影響を受けます
+- スケジュール実行は毎月1日 UTC 03:00（日本時間 12:00 正午）のため、通常の開発時間帯と重なる可能性があります
+
+#### dev DB を復旧する場合
+
+リストアテスト後に dev D1 を開発可能な状態に戻す手順:
+
+```bash
+# マイグレーション再適用でスキーマを復元
+cd apps/backend
+npm run db:migrate:dev:remote
+
+# 必要に応じてデータを再収集
+npm run collect -- --remote --env development
+```
+
+### 失敗時の対応
+
+リストアテストが失敗すると、自動的に GitHub Issue が起票されます（タイトル: `[自動] 月次リストアテスト失敗 (YYYY-MM-DD)`）。
+
+**確認手順:**
+
+1. GitHub Actions の **Actions** タブで `restore-test` のログを確認
+2. 失敗したステップを特定:
+   - `Get latest backup from R2`: R2 バケットにバックアップが存在するか確認
+   - `Restore backup to dev DB`: SQL 適用エラーの詳細を確認
+   - `Run integrity check`: どのチェックが失敗したか確認
+3. 必要に応じて手動で `workflow_dispatch` を使って再実行
+
+### 必要なシークレット
+
+バックアップ用シークレット（`backup-d1.yml` と共用）:
+
+| シークレット名 | 説明 |
+| --- | --- |
+| `CLOUDFLARE_API_TOKEN` | D1 アクセス権限を持つ Cloudflare API トークン |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare アカウント ID |
+| `R2_BACKUP_ACCESS_KEY_ID` | R2 バケットへの読み取り権限を持つ Access Key ID |
+| `R2_BACKUP_SECRET_ACCESS_KEY` | 対応する Secret Access Key |
+
+### 手動実行でテスト
+
+1. GitHub リポジトリの **"Actions"** タブを開く
+2. 左サイドバーの **"Monthly Restore Test"** をクリック
+3. **"Run workflow"** → **"Run workflow"** をクリック
+4. `Run integrity check` ステップが成功することを確認


### PR DESCRIPTION
## Summary

- R2バックアップからdev D1へのリストアを月次で自動検証するGitHub Actions workflowを追加
- 失敗時はGitHub Issueを自動起票し、開発者が即座に検知できるようにした
- dev DB破壊に関する警告をREADMEとドキュメントに追記

## Changes

### `.github/workflows/restore-test.yml`（新規追加）

毎月1日 UTC 03:00（日本時間 12:00）に実行されるリストアテストworkflow:

```
R2から最新バックアップ(.sql.gz)を取得
  → gzip解凍
  → dev D1 (gh-trends-db-dev) を初期化（全ユーザーテーブルをDROP）
  → バックアップSQLを適用
  → 整合性チェック（npm run db:check -- --remote --env development）
  → 失敗時: GitHub Issueを自動起票
```

- `workflow_dispatch` で手動実行も可能
- 既存の `apps/backend/scripts/check-db-integrity.ts` を再利用

### `README.md`

- 自動化ワークフロー一覧テーブルを追加
- リストアテスト実行中にdev DBが破壊される旨の警告を追記

### `docs/プロセス/GitHubActions設定.md`

- `restore-test.yml` の概要・フロー・失敗時対応・必要シークレットを追記

## Test plan

- [ ] `workflow_dispatch` で手動実行し、リストアが正常に完了することを確認
- [ ] R2に有効なバックアップが存在する状態でintegrityチェックが通過することを確認
- [ ] 失敗時にGitHub Issueが自動起票されることを確認

Closes #155

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7JbLR5DrzJaKYWQLsS4h4)_